### PR TITLE
docs: add page linking users to the ecosystem portal

### DIFF
--- a/docs/use-linea/explore.md
+++ b/docs/use-linea/explore.md
@@ -1,0 +1,7 @@
+---
+title: Explore dapps
+description: Explore dapps that are already deployed on Linea
+sidebar_position: 6
+---
+
+Are you excited to start playing with the various dapps already deployed on Linea? Check out the [Ecosystem Portal](https://goerli.linea.build/explore)! This page is continuously updated with new dapps as they get deployed to the Linea network.


### PR DESCRIPTION
I noticed that the [Use Linea](https://docs.linea.build/category/use-linea) page didn't link to the ecosystem portal, and I think it would be good to link users from there.