### PR TITLE
Remove boilerplate docusaurus deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,6 @@
 
 This documentation repo is built using [Docusaurus 2](https://docusaurus.io/).
 
-See [more](https://docs-template.consensys.net/) information about using Docusaurus quickly.
-
-### Local development
-
-    $ npm install
-    $ npm run prepare
-    $ npm start
-    $ git commit
-
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-### Build
-
-    $ npm run build
-    $ npm run serve
-
-This command generates static content into the `build` directory.
-
 ### Contributing
 
 #### Contributing to our docs


### PR DESCRIPTION
These are very helpful internal instructions; they're present on the (ConsenSys docs template)[https://github.com/ConsenSys/docs-template], but they essentially have to do with setting up/local development on the docs site itself. 

They won't generally be needed by the community, and starting off with that means you'll lose readers who think that the whole readme is boilerplate, like the create-react-app boilerplate.

# Pull request checklist

Use the following template to make sure your PR fits the ConsenSys documentation standard.

## Before creating the PR

Make sure that:

- [x] You've read the [contribution guidelines](https://docs-template.consensys.net/getting-started/style-guide).
- [x] You've previewed your changes locally.

## Describe the change

Removed the boilerplate Docusaurus instruction blocks, 'Local Development' and 'Build', from the Linea Docs readme.

## Issue fixed

N/A

## Impacted parts

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] Build and QA tools
- [ ] Node dependencies and JavaScript
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've fixed any issues raised by the tests.
- [ ] You've previewed your changes on Vercel below.
