### PR TITLE
docs: remove gitbook syntax from Snapshot X quest

### DIFF
--- a/docs/use-linea/explore/use-snapshotx.md
+++ b/docs/use-linea/explore/use-snapshotx.md
@@ -25,7 +25,7 @@ In case of Linea at the time of the quest every address has 1 Voting Power.
 
 # Quest - Cast a vote
 
-{% hint style="info" %} On-chain voting on Snapshot X doesn't cost you anything nor does it affect your funds in any way. {% endhint %}
+_On-chain voting on Snapshot X doesn't cost you anything nor does it affect your funds in any way._
 
 ### 1. Connect your wallet
 
@@ -47,7 +47,7 @@ Select the option you want to vote for - **Accept, Reject, Abstain**.
 
 Depending on the space settings you will have to sign a gasless Ethereum message and/or sign a transaction to confirm your action.
 
-{% hint style="info" %} If you are using MetaMask you'll need to scroll to the end of the signature and click on the arrow down for the Sign button to become active. Voting on Snapshot doesn't affect your account or the funds that are associated to it. {% endhint %}
+_If you are using MetaMask you'll need to scroll to the end of the signature and click on the arrow down for the Sign button to become active. Voting on Snapshot doesn't affect your account or the funds that are associated to it._
 
 You will notice that a new icon has appeared in the top right corner, just next to your avatar:
 


### PR DESCRIPTION
This PR removes Gitbook syntax for `hint` in the markdown