### PR TITLE
Fix broken link and center image in MetaMask article

### DIFF
--- a/docs/contact/provide-feedback.md
+++ b/docs/contact/provide-feedback.md
@@ -11,7 +11,7 @@ Otherwise, you can also fill out [**this form**](https://forms.gle/qR5SxqitPnQKF
 
 :::note
 
-Please only complete this form once you have [set up your wallet](../use-linea/set-up-your-wallet.md) and have tested the network.
+Please only complete this form once you have [set up your wallet](../use-linea/set-up-your-wallet.mdx) and have tested the network.
 
 :::
 

--- a/docs/developers/quickstart/deploy-smart-contract/foundry.md
+++ b/docs/developers/quickstart/deploy-smart-contract/foundry.md
@@ -15,7 +15,7 @@ Here's a video walkthrough:
 
 Before you begin, Ensure you've:
 
-1. [Set up your wallet](../../../use-linea/set-up-your-wallet.md)
+1. [Set up your wallet](../../../use-linea/set-up-your-wallet.mdx)
 1. [Funded your wallet with Linea ETH](../../../use-linea/fund.md#get-test-eth-on-linea)
 
    ```bash

--- a/docs/developers/quickstart/deploy-smart-contract/hardhat.md
+++ b/docs/developers/quickstart/deploy-smart-contract/hardhat.md
@@ -17,7 +17,7 @@ Here's a video walkthrough:
 
 Before you begin, ensure you've:
 
-1. [Set up your wallet](../../../use-linea/set-up-your-wallet.md)
+1. [Set up your wallet](../../../use-linea/set-up-your-wallet.mdx)
 1. [Funded your wallet with Linea ETH](../../../use-linea/fund.md#get-test-eth-on-linea)
 1. [Set up your environment using Hardhat's recommended instructions](https://hardhat.org/tutorial/setting-up-the-environment#2.-setting-up-the-environment).
 

--- a/docs/developers/quickstart/deploy-smart-contract/truffle.md
+++ b/docs/developers/quickstart/deploy-smart-contract/truffle.md
@@ -15,7 +15,7 @@ Here's a video walkthrough:
 
 Before you begin, ensure you've:
 
-1. [Set up your wallet](../../../use-linea/set-up-your-wallet.md)
+1. [Set up your wallet](../../../use-linea/set-up-your-wallet.mdx)
 1. [Funded your wallet with Linea ETH](../../../use-linea/fund.md#get-test-eth-on-linea)
 1. [Installed Truffle using the recommended installation procedure](https://trufflesuite.com/docs/truffle/how-to/install/).
 

--- a/docs/developers/quickstart/index.md
+++ b/docs/developers/quickstart/index.md
@@ -8,5 +8,5 @@ Linea is EVM equivalent, so you can use your favorite development tools out of t
 
 Before you begin, ensure you've:
 
-1. [Set up your wallet](../../use-linea/set-up-your-wallet.md)
+1. [Set up your wallet](../../use-linea/set-up-your-wallet.mdx)
 1. [Funded your wallet with Linea ETH](../../use-linea/fund.md#get-test-eth-on-linea)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,5 +15,5 @@ Linea released its public testnet 3/28 and is launching an upcoming NFT testnet 
 
 Check out our documentation on how to:
 
-1. [Set up your wallet](./use-linea/set-up-your-wallet.md)
+1. [Set up your wallet](./use-linea/set-up-your-wallet.mdx)
 2. [Deploy your first contract](./developers/quickstart/)

--- a/docs/use-linea/bridge-funds/index.md
+++ b/docs/use-linea/bridge-funds/index.md
@@ -10,5 +10,5 @@ You can find examples of how to bridge other tokens such as BNB and MATIC by exp
 
 Before you begin, ensure you've:
 
-1. [Set up your wallet](../../use-linea/set-up-your-wallet.md)
+1. [Set up your wallet](../../use-linea/set-up-your-wallet.mdx)
 1. [Funded your wallet with goerli ETH](../../use-linea/fund.md#get-test-eth-on-goerli)

--- a/docs/use-linea/bridge-funds/use-bridge-ui.md
+++ b/docs/use-linea/bridge-funds/use-bridge-ui.md
@@ -12,7 +12,7 @@ The following steps take you through bridging USDC and Goerli ETH using the Hop 
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md)
+1. [Configured to use Linea](../set-up-your-wallet.mdx)
 1. [Funded with test tokens](../fund.md#get-test-eth-on-goerli)
 
 ## Bridge from Goerli to Linea

--- a/docs/use-linea/bridge-funds/use-etherscan.md
+++ b/docs/use-linea/bridge-funds/use-etherscan.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md)
+1. [Configured to use Linea](../set-up-your-wallet.mdx)
 1. [Funded with test tokens](../fund.md#get-test-eth-on-goerli)
 
 ## Bridge ETH from Goerli to Linea

--- a/docs/use-linea/explore/use-apetimism-launchpad.md
+++ b/docs/use-linea/explore/use-apetimism-launchpad.md
@@ -10,7 +10,7 @@ Apetimism Launchpad is a no-code platform that allows you to create, manage, and
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 2. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli)
 
 ## Mint an NFT

--- a/docs/use-linea/explore/use-battlemon.md
+++ b/docs/use-linea/explore/use-battlemon.md
@@ -10,7 +10,7 @@ A GameFi ecosystem built around interactive 3D NFTs with utilities and on-chain 
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 
 2. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli)
 

--- a/docs/use-linea/explore/use-bilinear.md
+++ b/docs/use-linea/explore/use-bilinear.md
@@ -18,7 +18,7 @@ Within the marketplace, a user will be able to perform the following actions:
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 1. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli)
 
 ## Mint a collection

--- a/docs/use-linea/explore/use-celer.md
+++ b/docs/use-linea/explore/use-celer.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 
 In this guide, we'll walk you through how to bridge TBNB and tBUSD from Binance Smart Chain (BSC) over to Linea!
 
-Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.md).
+Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.mdx).
 
 ## Add BSC testnet to your MetaMask wallet
 

--- a/docs/use-linea/explore/use-connext.md
+++ b/docs/use-linea/explore/use-connext.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 
 In this guide, we'll walk you through how to bridge MATIC from Polygon over to Linea!
 
-Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.md).
+Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.mdx).
 
 ## Add Polygon Mumbai to your wallet
 

--- a/docs/use-linea/explore/use-fwdx.md
+++ b/docs/use-linea/explore/use-fwdx.md
@@ -14,7 +14,7 @@ In this guide, we'll walk you through how to Create Market, Swap & Fill Markets 
 
 Before you start, make sure your wallet is configured as follows:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 2. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli)
 3. [Funded with Linea Faucet ERC20 Tokens](https://faucet.goerli.linea.build/)
 

--- a/docs/use-linea/explore/use-ghost.md
+++ b/docs/use-linea/explore/use-ghost.md
@@ -9,7 +9,7 @@ ghostNFT is the first application of ERC721Envious Standard aimed at adding coll
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 1. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli) (at least .06 ETH)
 
 ## Get DAI on Linea testnet

--- a/docs/use-linea/explore/use-hop.md
+++ b/docs/use-linea/explore/use-hop.md
@@ -11,7 +11,7 @@ In this guide, we'll walk you through how to bridge Goerli ETH using Hop over to
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 1. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli)
 
 ## Bridge Goerli ETH to Linea

--- a/docs/use-linea/explore/use-idriss.md
+++ b/docs/use-linea/explore/use-idriss.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 
 In this guide, we'll walk you through how to send crypto directly on Twitter with the IDriss browser extension using Linea!
 
-Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.md) and [funded with Goerli ETH](../fund.md#get-test-eth-on-goerli).
+Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.mdx) and [funded with Goerli ETH](../fund.md#get-test-eth-on-goerli).
 
 ## Send crypto directly on Twitter
 

--- a/docs/use-linea/explore/use-kyberswap.md
+++ b/docs/use-linea/explore/use-kyberswap.md
@@ -20,7 +20,7 @@ With KyberSwap you can:
 
 Before you embark on the future of trade, make sure that you have:
 
-- [Connected your wallet to the Linea network](../set-up-your-wallet.md)
+- [Connected your wallet to the Linea network](../set-up-your-wallet.mdx)
 - [Acquired Goerli ETH to pay for your Linea transactions](../fund.md)
 
 :::

--- a/docs/use-linea/explore/use-linea-l2-domains.md
+++ b/docs/use-linea/explore/use-linea-l2-domains.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 
 In this guide, we'll walk you through how to buy a username!
 
-Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.md).
+Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.mdx).
 
 ## Buy a Username
 

--- a/docs/use-linea/explore/use-meeet.md
+++ b/docs/use-linea/explore/use-meeet.md
@@ -11,7 +11,7 @@ MEEET aims to introduce a variety of game products to its ecosystem and encourag
 
 Before you begin, make sure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 1. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli)
 
 ## Claim Free MML NFT on Linea Testnet

--- a/docs/use-linea/explore/use-mesprotocol.md
+++ b/docs/use-linea/explore/use-mesprotocol.md
@@ -9,7 +9,7 @@ Linea DeFi Week Tutorial MES Protocol is a cross-rollup orderbook DEX, you can l
 
 Before you begin, make sure your wallet is:
 
-- [configured to use Linea](../set-up-your-wallet.md)
+- [configured to use Linea](../set-up-your-wallet.mdx)
 - [funded with the Linea ETH](../fund.md#get-test-eth-on-linea).
 
 ## Tasks

--- a/docs/use-linea/explore/use-multichain.md
+++ b/docs/use-linea/explore/use-multichain.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 
 In this guide, we'll walk you through how to bridge TUSD and EUROe using Multichain over to Linea!
 
-Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.md).
+Before you begin, ensure your wallet is [configured to use Linea](../set-up-your-wallet.mdx).
 
 ## Add Avalanche Fuji testnet to your MetaMask wallet
 

--- a/docs/use-linea/explore/use-nfts2me.md
+++ b/docs/use-linea/explore/use-nfts2me.md
@@ -15,7 +15,7 @@ In this guide, we'll walk you through the steps to create a new NFT collection, 
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 1. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli)
 
 ## Create a new NFT Collection​ (using AI)

--- a/docs/use-linea/explore/use-noobysswap.md
+++ b/docs/use-linea/explore/use-noobysswap.md
@@ -12,7 +12,7 @@ In this guide, we'll walk you through how to Swap & Add LP with NooBysSwap.io.
 
 Before you begin, make sure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 2. [Funded with Linea ETH](../fund.md#get-test-eth-on-linea)
 
 Claim USDT & NBS token on Faucet

--- a/docs/use-linea/explore/use-tatarot.md
+++ b/docs/use-linea/explore/use-tatarot.md
@@ -13,7 +13,7 @@ This guide will provide step-by-step instructions on how to mint a magical Tatar
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md)
+1. [Configured to use Linea](../set-up-your-wallet.mdx)
 1. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli)
 
 ## Mint a Tatarot NFT card

--- a/docs/use-linea/explore/use-zkex.md
+++ b/docs/use-linea/explore/use-zkex.md
@@ -15,7 +15,7 @@ If you get stuck, our friendly community support team on our [Discord](https://d
 
 Ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 2. [Funded with Goerli ETH (at least 0.1 ETH)](../fund.md#get-test-eth-on-goerli)
 
 ## Import the $LineaPEPE token to your wallet

--- a/docs/use-linea/explore/use-zonic.md
+++ b/docs/use-linea/explore/use-zonic.md
@@ -12,7 +12,7 @@ In this guide, we will walk you through the fundamental functions of the Zonic N
 
 Before you begin, ensure your wallet is:
 
-1. [Configured to use Linea](../set-up-your-wallet.md).
+1. [Configured to use Linea](../set-up-your-wallet.mdx).
 2. [Funded with Goerli ETH](../fund.md#get-test-eth-on-goerli)
 
 ## Listing your NFT for sale

--- a/docs/use-linea/fund.md
+++ b/docs/use-linea/fund.md
@@ -4,7 +4,7 @@ description: Get test tokens on Linea
 sidebar_position: 3
 ---
 
-Before you begin, ensure your wallet is [configured to use Linea](./set-up-your-wallet.md)
+Before you begin, ensure your wallet is [configured to use Linea](./set-up-your-wallet.mdx)
 
 # Use a Linea faucet
 

--- a/docs/use-linea/index.md
+++ b/docs/use-linea/index.md
@@ -7,7 +7,7 @@ Linea is meant to be fully compatible with Ethereum, full stop. There are alread
 
 This section should walk you through everything you need to get started:
 
-1. [Set up your wallet](./set-up-your-wallet.md)
+1. [Set up your wallet](./set-up-your-wallet.mdx)
 2. [Bridge some funds](./bridge-funds/index.md)
 3. [Deploy your first contract](./../developers/quickstart/)
 4. [Get funds from a faucet](./fund.md)

--- a/docs/use-linea/set-up-your-wallet.mdx
+++ b/docs/use-linea/set-up-your-wallet.mdx
@@ -17,8 +17,9 @@ All you need to interact with Linea is to download MetaMask, which you can [inst
 
 Because Linea is currently only in public testnet, in MetaMask Extension, you'll need to click on `Show/hide test networks` to have it displayed, as indicated in the image below. Afterwards, select the Linea network, and you're good to go.
 
-
-<img src={metamaskwallet} alt="Linea in your foxy wallet"></img>
+<div class="text--center">
+<img src={metamaskwallet} alt="Linea in your foxy wallet"width="40%" height="20%"></img>
+</div>
 
 ## Using Linea on MetaMask Mobile
 

--- a/docs/use-linea/set-up-your-wallet.mdx
+++ b/docs/use-linea/set-up-your-wallet.mdx
@@ -4,6 +4,9 @@ description: Set up your wallet to start using Linea
 sidebar_position: 2
 ---
 
+import metamaskwallet from './../../static/img/metamaskwallet.png'
+
+
 Linea is designed to be completely compatible with Ethereum. Because of that, **it works with MetaMask right out of the box**. (If you're not familiar with the identity manager, wallet, and web3 passport that is MetaMask, [get started here](https://support.metamask.io/hc/en-us/articles/360015489531)).
 
 In fact, **the MetaMask extension wallet provides connections to the Linea testnet already built-in**. There's no special wallet setup necessary! The only thing you'll need to do is switch to Linea; if you need some pointers, follow [MetaMask's instructions here](https://support.metamask.io/hc/en-us/articles/16367251716251).
@@ -14,9 +17,8 @@ All you need to interact with Linea is to download MetaMask, which you can [inst
 
 Because Linea is currently only in public testnet, in MetaMask Extension, you'll need to click on `Show/hide test networks` to have it displayed, as indicated in the image below. Afterwards, select the Linea network, and you're good to go.
 
-<div class="text--center">
-<img src="./../../static/img/metamaskwallet.png" alt="metamask wallet" width="40%" height="20%"/>
-</div>
+
+<img src={metamaskwallet} alt="Linea in your foxy wallet"></img>
 
 ## Using Linea on MetaMask Mobile
 


### PR DESCRIPTION
In order to display the image with any kind of formatting (scaling, for example), the file needed to be .mdx, not .md.

Did that, added scaling, etc.