### PR TITLE
Insert ganache.dev in an iframe for RPC documentation

### DIFF
--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -7,3 +7,9 @@ sidebar_position: 4
 # JSON-RPC API
 
 Linea uses the [Ethereum JSON-RPC API](https://eth.wiki/json-rpc/API). This is because the zkEVM is EVM-equivalent, meaning that the developer experience is identical to building on Ethereum itself.
+
+Check out Truffle's documentation of the Ethereum API below (also available at [ganache.dev](https://ganache.dev)); it's got categorized methods, it's got **interactive code sandboxes**, and nice colors.
+<>
+  <iframe width="100%" height="900" src="https://ganache.dev/" frameBorder="0" allowFullScreen />
+</>
+


### PR DESCRIPTION
Our RPC documentation could be a lot better. Ganache.dev is sick. Let's make this beautiful.