### PR TITLE
Fixing routes to pages under /use-linea-testnet/

### DIFF
--- a/docs/build-on-linea/quickstart/deploy-smart-contract/foundry.md
+++ b/docs/build-on-linea/quickstart/deploy-smart-contract/foundry.md
@@ -67,3 +67,7 @@ Transaction hash: 0x967e1290b285e67b3d74940ee19925416734c345f58bd1ec64dcea134647
 ```
 
 Next, you can optionally [verify your contract on the network](../verify-smart-contract/foundry.md).
+
+## Deploy to Mainnet
+
+_Instructions coming soon!_

--- a/docs/build-on-linea/quickstart/deploy-smart-contract/hardhat.mdx
+++ b/docs/build-on-linea/quickstart/deploy-smart-contract/hardhat.mdx
@@ -15,9 +15,9 @@ Here's a video walkthrough:
 
 Before you begin, ensure you've:
 
-1. [Set up your wallet](/use-mainnet/set-up-your-wallet.mdx)
-1. [Funded your wallet with Linea ETH](/use-mainnet/fund.md#get-test-eth-on-linea)
-1. [Set up your environment using Hardhat's recommended instructions](https://hardhat.org/tutorial/setting-up-the-environment#2.-setting-up-the-environment).
+1. [Set up your wallet](/build-on-linea/use-linea-testnet/set-up-your-wallet.mdx)
+2. [Funded your wallet with Linea ETH](/build-on-linea/use-linea-testnet/fund.md#get-test-eth-on-linea)
+3. [Set up your environment using Hardhat's recommended instructions](https://hardhat.org/tutorial/setting-up-the-environment#2.-setting-up-the-environment).
 
 ## Create a Hardhat project
 

--- a/docs/build-on-linea/quickstart/deploy-smart-contract/hardhat.mdx
+++ b/docs/build-on-linea/quickstart/deploy-smart-contract/hardhat.mdx
@@ -224,3 +224,7 @@ To deploy to Linea, we'll need to add the network to our `hardhat.config.js`. To
    ```
 
 Next, you can optionally [verify your contract on the network](/build-on-linea/quickstart/verify-smart-contract/hardhat.md).
+
+## Deploy to Mainnet
+
+_Instructions coming soon!_

--- a/docs/build-on-linea/quickstart/deploy-smart-contract/thirdweb.md
+++ b/docs/build-on-linea/quickstart/deploy-smart-contract/thirdweb.md
@@ -92,3 +92,7 @@ Deploy allows you to deploy a smart contract to any EVM compatible network witho
 > For additional information on Deploy, please reference [thirdweb’s documentation](https://portal.thirdweb.com/deploy).
 
 If you have any further questions or encounter any issues during the process, please [reach out to thirdweb support](https://support.thirdweb.com).
+
+## Deploy to Mainnet
+
+_Instructions coming soon!_

--- a/docs/build-on-linea/quickstart/deploy-smart-contract/truffle.mdx
+++ b/docs/build-on-linea/quickstart/deploy-smart-contract/truffle.mdx
@@ -15,9 +15,9 @@ Here's a video walkthrough:
 
 Before you begin, ensure you've:
 
-1. [Set up your wallet](/use-mainnet/set-up-your-wallet.mdx)
-1. [Funded your wallet with Linea ETH](/use-mainnet/fund.md#get-test-eth-on-linea)
-1. [Installed Truffle using the recommended installation procedure](https://trufflesuite.com/docs/truffle/how-to/install/).
+1. [Set up your wallet](/build-on-linea/use-linea-testnet/set-up-your-wallet.mdx)
+2. [Funded your wallet with Linea ETH](/build-on-linea/use-linea-testnet/fund.md#get-test-eth-on-linea)
+3. [Installed Truffle using the recommended installation procedure](https://trufflesuite.com/docs/truffle/how-to/install/).
 
 ## Create a Truffle project
 

--- a/docs/build-on-linea/quickstart/deploy-smart-contract/truffle.mdx
+++ b/docs/build-on-linea/quickstart/deploy-smart-contract/truffle.mdx
@@ -90,6 +90,10 @@ module.exports = function (deployer) {
 
 Truffle allows you to deploy through the [Truffle Dashboard](#truffle-dashboard) using your MetaMask wallet!
 
+## Deploy to Mainnet
+
+_Instructions coming soon!_
+
 ### Truffle Dashboard
 
 [Truffle Dashboard](https://trufflesuite.com/docs/truffle/how-to/use-the-truffle-dashboard/) allows you to forgo saving your private keys locally, instead connecting to your MetaMask wallet for deployments. To deploy with Truffle Dashboard, you need to:

--- a/docs/build-on-linea/quickstart/index.md
+++ b/docs/build-on-linea/quickstart/index.md
@@ -8,5 +8,5 @@ Linea is EVM equivalent, so you can use your favorite development tools out of t
 
 Before you begin, ensure you've:
 
-1. [Set up your wallet](/use-mainnet/set-up-your-wallet.mdx)
-1. [Funded your wallet with Linea ETH](/use-mainnet/fund.md#get-test-eth-on-linea)
+1. [Set up your wallet](/set-up-your-wallet.mdx)
+1. [Funded your wallet with Linea ETH](/build-on-linea/use-linea-testnet/fund.md#get-test-eth-on-linea)

--- a/docs/build-on-linea/quickstart/index.md
+++ b/docs/build-on-linea/quickstart/index.md
@@ -11,4 +11,4 @@ It's always best practice to work on a test network before deploying a contract 
 Before you begin, ensure you've:
 
 1. [Set up your wallet for Testnet](/build-on-linea/use-linea-testnet/set-up-your-wallet.mdx)
-1. [Funded your wallet with Testnet Linea ETH](/build-on-linea/use-linea-testnet/fund.md#get-test-eth-on-linea)
+2. [Funded your wallet with Testnet Linea ETH](/build-on-linea/use-linea-testnet/fund.md#get-test-eth-on-linea)

--- a/docs/build-on-linea/quickstart/index.md
+++ b/docs/build-on-linea/quickstart/index.md
@@ -6,7 +6,9 @@ title: Quickstart
 
 Linea is EVM equivalent, so you can use your favorite development tools out of the box. In this quickstart, we'll walk through deploying and verifying your smart contracts on Linea using Truffle, Hardhat, and Foundry.
 
+It's always best practice to work on a test network before deploying a contract to a live public blockchain network; that way you can make sure everything's working the way you mean it to, without spending "real" tokens.
+
 Before you begin, ensure you've:
 
-1. [Set up your wallet](/set-up-your-wallet.mdx)
-1. [Funded your wallet with Linea ETH](/build-on-linea/use-linea-testnet/fund.md#get-test-eth-on-linea)
+1. [Set up your wallet for Testnet](/build-on-linea/use-linea-testnet/set-up-your-wallet.mdx)
+1. [Funded your wallet with Testnet Linea ETH](/build-on-linea/use-linea-testnet/fund.md#get-test-eth-on-linea)

--- a/docs/build-on-linea/use-linea-testnet/fund.md
+++ b/docs/build-on-linea/use-linea-testnet/fund.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Before you begin, ensure your wallet is [configured to use Linea](./set-up-your-wallet.mdx)
 
-# Use a Linea faucet
+## Use a Linea faucet
 
 If you want to drip Goerli ETH directly to Linea, the following faucets are available. Note that you will need to enter your actual address — ENS names will not work.
 

--- a/docs/build-on-linea/use-linea-testnet/index.md
+++ b/docs/build-on-linea/use-linea-testnet/index.md
@@ -7,10 +7,10 @@ Linea is meant to be fully compatible with Ethereum, full stop. There are alread
 
 This section should walk you through everything you need to get started:
 
-1. [Set up your wallet](/use-mainnet/set-up-your-wallet.mdx)
-2. [Bridge some funds](./bridge-funds/index.md)
+1. [Set up your wallet](/build-on-linea/use-linea-testnet/set-up-your-wallet)
+2. [Bridge some funds](/build-on-linea/use-linea-testnet/bridge-funds)
 3. [Deploy your first contract](/build-on-linea/quickstart/)
-4. [Get funds from a faucet](./fund.md)
-5. [Send a transaction](./transact.md)
+4. [Get funds from a faucet](/build-on-linea/use-linea-testnet/fund)
+5. [Send a transaction](/build-on-linea/use-linea-testnet/transact)
 
 If you run into a problem, step on over to the [Linea Support page](https://support.linea.build/hc/en-us) and let us know.

--- a/docs/use-mainnet/bridges-of-linea/index.mdx
+++ b/docs/use-mainnet/bridges-of-linea/index.mdx
@@ -2,6 +2,10 @@
 title: Bridge your tokens
 sidebar_position: 4
 --- 
+
+_Note: Linea is currently doing a soft launch of Mainnet with specific partners. Public availability will be announced soon. Meanwhile, feel free to check out our [testnet docs](/build-on-linea/use-linea-testnet/bridge-funds)_
+
+
 <!--!
 # Linea, the land of many bridges
 

--- a/docs/use-mainnet/fund.md
+++ b/docs/use-mainnet/fund.md
@@ -3,6 +3,7 @@ title: Fund your accounts
 description: Get tokens in your accounts
 sidebar_position: 3
 ---
+_Note: Linea is currently doing a soft launch of Mainnet with specific partners. Public availability will be announced soon. Meanwhile, feel free to check out our [testnet docs](/build-on-linea/use-linea-testnet/fund.md)_
 
 <!-- Before you begin, ensure your wallet is [configured to use Linea](./set-up-your-wallet.mdx)
 

--- a/docs/use-mainnet/set-up-your-wallet.mdx
+++ b/docs/use-mainnet/set-up-your-wallet.mdx
@@ -3,7 +3,11 @@ title: Set up your wallet
 description: Set up your wallet to start using Linea
 sidebar_position: 1
 ---
-<!--! 
+
+_Note: Linea is currently doing a soft launch of Mainnet with specific partners. Public availability will be announced soon. Meanwhile, feel free to check out our [testnet docs](/build-on-linea/use-linea-testnet/set-up-your-wallet.mdx)_
+
+
+<!--!
 Linea is designed to be completely compatible with Ethereum. Because of that, **it works with MetaMask right out of the box**. (If you're not familiar with the identity manager, wallet, and web3 passport that is MetaMask, [get started here](https://support.metamask.io/hc/en-us/articles/360015489531)).
 
 In fact, **the MetaMask extension wallet provides connections to the Linea testnet already built-in**. There's no special wallet setup necessary! The only thing you'll need to do is switch to Linea; if you need some pointers, follow [MetaMask's instructions here](https://support.metamask.io/hc/en-us/articles/16367251716251).
@@ -63,5 +67,5 @@ If you've got some Goerli ETH, or want to [swap for some](https://support.metama
 
 If you're having technical difficulties, it can sometimes be hard to figure out where the problem is. The good news is, there's a lot of good support available to you in our ecosystem.
 
-If you're interacting with a dapp on Linea, try that dapp's documentation and resources first. If you can't find your answer there, take a look at the [Linea Support Help Center](https://support.linea.build), and search on the [Linea Community Forums](https://community.linea.build) for related issues. If it seems like a MetaMask issue at that point, jump over to [MetaMask's Help Center](https://support.metamask.io), where you can explore their forums, and start a conversation with Support staff.
+If you're interacting with a dapp on Linea, try that dapp's documentation and resources first. If you can't find your answer there, take a look at the [Linea Support Help Center](https://support.linea.build), and search on the [Linea Community Forums](https://community.linea.build) for related issues. If it seems like a MetaMask issue at that point, jump over to [MetaMask's Help Center](https://support.metamask.io), where you can explore their forums, and start a conversation with Support staff. 
 -->

--- a/docs/use-mainnet/transact.md
+++ b/docs/use-mainnet/transact.md
@@ -3,6 +3,9 @@ title: Transact
 description: Send tokens between accounts
 sidebar_position: 3
 ---
+
+_Note: Linea is currently doing a soft launch of Mainnet with specific partners. Public availability will be announced soon. Meanwhile, feel free to check out our [testnet docs](/build-on-linea/use-linea-testnet/)_
+
 <!-- 
 # Transfer funds between accounts
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -292,7 +292,7 @@ const config = {
               "/get-started/configure-metamask",
               "/get-started/quickstart",
               "/use-zkevm",
-              "/use-linea",
+              "/use-linea/",
             ],
           },
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -292,7 +292,10 @@ const config = {
               "/get-started/configure-metamask",
               "/get-started/quickstart",
               "/use-zkevm",
-              "/use-linea/",
+              "/use-linea/fund",
+              "/use-linea/bridge-funds",
+              "/use-linea/explore",
+              "/use-linea/index.md",
             ],
           },
           {


### PR DESCRIPTION
This ensures that dapp deploying tutorials link to the Testnet wallet funding instructions, clarifies a few things about testnet vs Mainnet, and introduces some explanatory copy that will hopefully reduce confusion.