### PR TITLE
added third party messaging page (LayerZero)

### DIFF
--- a/docs/architecture/bridges/third-party-cross-chain.mdx
+++ b/docs/architecture/bridges/third-party-cross-chain.mdx
@@ -1,0 +1,51 @@
+---
+title: Third Party Messaging Services
+sidebar_position: 3
+---
+
+# Third Party Messaging Services
+
+There are other third party messaging services which can enable your contracts to communicate across different blockchains.
+
+## LayerZero
+
+LayerZero is an omnichain interoperability protocol that enables cross-chain messaging. Applications built on Linea can use the LayerZero protocol to connect to 35+ supported blockchains seamlessly. 
+
+LayerZero's Endpoint has been deployed on Linea for builders to leverage Omnichain Messaging in their dApps. LayerZero’s Endpoint ULNv2 validation library relies on two parties, the Oracle and Relayer, to transfer messages between on-chain endpoints. When LayerZero sends a message from Linea to chain X, the message is routed through the endpoint on Linea to the ULNv2 validation library. The ULNv2 library notifies the Oracle and Relayer of the message and its destination chain X. The Oracle forwards the packet hash to the endpoint on chain X, and the Relayer submits the packet to be verified on-chain against the hash and delivers the message.
+
+As a developer, LayerZero Endpoint is the only interface for your User Application (UA). The Endpoint allows UAs to configure the Messaging Library for sending and receiving verified messages and guarantees the message-delivering ordering across all messaging libraries.
+Send(): the message will be sent through the endpoint first and then redirected to the UA-configured Messaging Library.
+Receive(): the message will be verified at the Messaging Library first then forwarded to the endpoint and eventually delivered to the UA. 
+
+Learn how to integrate LayerZero into your contracts <a href="https://layerzero.gitbook.io/docs/">here</a>. 
+
+<table>
+  <tbody>
+    <tr>
+      <th>Contract</th>
+      <th>Chain Name</th>
+      <th>Chain Id</th>
+      <th>Endpoint</th>
+    </tr>
+    <tr>
+      <td>Testnet</td>
+      <td>Linea</td>
+      <td>10157</td>
+      <td>
+        <a href="https://goerli.basescan.org/address/0x6aB5Ae6822647046626e83ee6dB8187151E1d5ab">
+          0x6aB5Ae6822647046626e83ee6dB8187151E1d5ab
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>Mainnet</td>
+      <td>Linea</td>
+      <td>183</td>
+      <td>
+        <a href="https://basescan.org/address/0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7#code">
+          0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7
+        </a>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6615,6 +6615,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
Added under Architecture of Linea => Bridges => Third Party Messaging Services page that currently shows LayerZero's offering for cross-chain messaging, a brief description of how LayerZero works, links to our docs for further reading, and our endpoint addresses for devs to immediately start using. 