### PR TITLE
Fix typo hardhat - truffle

### DIFF
--- a/docs/build-on-linea/quickstart/deploy-smart-contract/truffle.mdx
+++ b/docs/build-on-linea/quickstart/deploy-smart-contract/truffle.mdx
@@ -184,7 +184,7 @@ You can deploy with Truffle using the command line, by specifying the Linea in `
     </TabItem>
     <TabItem value="Public Endpoint" label="Public Endpoint">
 
-    The public endpoints are rate limited and not meant for production systems. However, you can use the public endpoints by modifying `hardhat.config.js` as follows:
+    The public endpoints are rate limited and not meant for production systems. However, you can use the public endpoints by modifying `truffle-config.js` as follows:
 
     ```javascript
     require("dotenv").config();


### PR DESCRIPTION
Change hardhat.config.js to truffle-config.js in Truffle documentation.