### PR TITLE
chore: update block time for mainnet genesis.json

### DIFF
--- a/static/files/genesis.json
+++ b/static/files/genesis.json
@@ -12,7 +12,7 @@
         "berlinBlock": 0,
         "londonBlock": 0,
         "clique": {
-            "period": 12,
+            "period": 1,
             "epoch": 30000
         }
     },


### PR DESCRIPTION
update block time from `12s` to `1s` for mainnet genesis.json