### PR TITLE
Implementing MetaMask Portfolio Bridging

### DIFF
--- a/blog/2023-05-31-tracking-nft-linea-hal.md
+++ b/blog/2023-05-31-tracking-nft-linea-hal.md
@@ -43,7 +43,7 @@ Next, enter the contract address of the NFT you want to monitor. Make sure this 
 
 ![Contract address](assets/hal-stream/hal-stream-2.png)
 
-After adding the contract address, click "Continue". You will have the option to filter event data. To track NFT minting, you want to monitor the 'transfer' event, and more specifically, with the 0X0000… address in the ‘from’ field (as per the ERC721 standard). To do this, select the event from the event list and click "Add filter" to specify the ‘from’ address.
+After adding the contract address, click "Continue". You will have the option to filter event data. To track NFT minting, you want to monitor the 'transfer' event, and more specifically, with the 0X0000… address in the ‘from’ field (as per the ERC-721 standard). To do this, select the event from the event list and click "Add filter" to specify the ‘from’ address.
 
 ![Filtering](assets/hal-stream/hal-stream-3.png)
 

--- a/blog/2023-09-12-index-live-greeter-contract-using-envio.md
+++ b/blog/2023-09-12-index-live-greeter-contract-using-envio.md
@@ -76,7 +76,7 @@ Choose `Greeter` when prompted to choose template.
 ? Which template would you like to use?
   "Blank"
 > "Greeter"
-  "Erc20"
+  "ERC-20"
 [↑↓ to move, enter to select, type to filter]
 ```
 

--- a/docs/build-on-linea/linea-version/index.mdx
+++ b/docs/build-on-linea/linea-version/index.mdx
@@ -82,7 +82,7 @@ This release focuses on testing a substantial architecture upgrade in preparatio
       - Outer proof system moved from Groth16 to Plonk + custom gates to support efficient Fiat Shamir, c.f.: https://eprint.iacr.org/2022/1072.pdf section 6.2
     - Messaging Service
       - Changed the message service model by splitting the delivery into anchoring and claiming of messages to allow more flexible workflows, remove the mandatory fee for L1→L2, reduce the mandatory fee for L2→L1
-  - Canonical Token Bridge: Upgrade from 1-1 ERC20 basic token bridge to N-N ERC20 canonical token bridge with reservation and token registry
+  - Canonical Token Bridge: Upgrade from 1-1 ERC-20 basic token bridge to N-N ERC-20 canonical token bridge with reservation and token registry
 - Add Postman Service for message execution
   - The Postman Service is Linea’s off-chain message delivery service. It’s decentralized, permissionless, and used to claim messages once the protocol has anchored the message hashes. The first release will only contain the following scenarios:
     - DApps/protocols operating the SDK (to be released) claiming messages and paying for gas

--- a/docs/build-on-linea/quickstart/deploy-smart-contract/thirdweb.md
+++ b/docs/build-on-linea/quickstart/deploy-smart-contract/thirdweb.md
@@ -18,12 +18,12 @@ To create a new smart contract using thirdweb [CLI](https://portal.thirdweb.com/
    1. Give your project a name
    2. Choose your preferred framework: Hardhat or Foundry
    3. Name your smart contract
-   4. Choose the type of base contract: Empty, [ERC20](https://portal.thirdweb.com/solidity/base-contracts/erc20base), [ERC721](https://portal.thirdweb.com/solidity/base-contracts/erc721base), or [ERC1155](https://portal.thirdweb.com/solidity/base-contracts/erc1155base)
+   4. Choose the type of base contract: Empty, [ERC-20](https://portal.thirdweb.com/solidity/base-contracts/ERC-20base), [ERC-721](https://portal.thirdweb.com/solidity/base-contracts/erc721base), or [ERC-1155](https://portal.thirdweb.com/solidity/base-contracts/erc1155base)
    5. Add any desired [extensions](https://portal.thirdweb.com/solidity/extensions)
 3. Once created, navigate to your project’s directory and open in your preferred code editor.
 4. If you open the `contracts` folder, you will find your smart contract; this is your smart contract written in Solidity.
 
-   The following is code for an `ERC721Base` contract without specified extensions. It implements all of the logic inside the [ERC721Base.sol](https://github.com/thirdweb-dev/contracts/blob/main/contracts/base/ERC721Base.sol) contract; which implements the [ERC721A](https://github.com/thirdweb-dev/contracts/blob/main/contracts/eip/ERC721A.sol) standard.
+   The following is code for an `ERC721Base` contract without specified extensions. It implements all of the logic inside the [ERC721Base.sol](https://github.com/thirdweb-dev/contracts/blob/main/contracts/base/ERC721Base.sol) contract; which implements the [ERC-721A](https://github.com/thirdweb-dev/contracts/blob/main/contracts/eip/ERC721A.sol) standard.
 
    ```bash
    // SPDX-License-Identifier: MIT

--- a/docs/build-on-linea/tooling/data-indexers/envio.md
+++ b/docs/build-on-linea/tooling/data-indexers/envio.md
@@ -26,7 +26,7 @@ HyperSync is an indexed layer of the Linea blockchain, providing accelerated API
 
 - Detailed logging and error messaging are provided for effective troubleshooting and debugging.
 
-- Quickstart templates with pre-defined indexing logic for popular OpenZeppelin contracts (ERC-20, ERC-721, ERC1155, etc.)
+- Quickstart templates with pre-defined indexing logic for popular OpenZeppelin contracts (ERC-20, ERC-721, ERC-1155, etc.)
 
 ## Getting Started
 

--- a/docs/build-on-linea/tooling/data-indexers/envio.md
+++ b/docs/build-on-linea/tooling/data-indexers/envio.md
@@ -26,7 +26,7 @@ HyperSync is an indexed layer of the Linea blockchain, providing accelerated API
 
 - Detailed logging and error messaging are provided for effective troubleshooting and debugging.
 
-- Quickstart templates with pre-defined indexing logic for popular OpenZeppelin contracts (ERC20, ERC721, ERC1155, etc.)
+- Quickstart templates with pre-defined indexing logic for popular OpenZeppelin contracts (ERC-20, ERC-721, ERC1155, etc.)
 
 ## Getting Started
 
@@ -55,7 +55,7 @@ Then choose a template out of the possible options
 ? Which template would you like to use?
 > "Blank"
   "Greeter"
-  "Erc20"
+  "ERC-20"
 [↑↓ to move, enter to select, type to filter]
 ```
 

--- a/docs/build-on-linea/tooling/data-indexers/flair.md
+++ b/docs/build-on-linea/tooling/data-indexers/flair.md
@@ -103,7 +103,7 @@ Explore real-world usage of Flair indexing primitives for various use-cases.
 
 ### NFT
 
-* [Index ERC721 and ERC-1155 NFTs on any EVM chain with an RPC URL](https://github.com/flair-sdk/examples/tree/main/erc721-and-erc1155-nft-indexing)
+* [Index ERC-721 and ERC-1155 NFTs on any EVM chain with an RPC URL](https://github.com/flair-sdk/examples/tree/main/erc721-and-erc1155-nft-indexing)
 
 ## Need help?
 

--- a/docs/build-on-linea/tooling/data-indexers/flair.md
+++ b/docs/build-on-linea/tooling/data-indexers/flair.md
@@ -28,7 +28,7 @@ Compared to other alternatives the main reasons are:
   * Auto-track new contracts deployed from factory contracts.
 * ✅ **Custom processor scripts** with Javascript runtime (with **Typescript** support)
   * Make external API or Webhook calls to third-party or your backend.
-  * Get current or historical USD value of any ERC20 token amount of any contract address on any chain.
+  * Get current or historical USD value of any ERC-20 token amount of any contract address on any chain.
   * Use any external NPM library.
 * ✅ **Stream** any stored data to your destination database (Postgres, MongoDB, MySQL, Kafka, Elasticsearch, Timescale, etc).
 
@@ -103,7 +103,7 @@ Explore real-world usage of Flair indexing primitives for various use-cases.
 
 ### NFT
 
-* [Index ERC721 and ERC1155 NFTs on any EVM chain with an RPC URL](https://github.com/flair-sdk/examples/tree/main/erc721-and-erc1155-nft-indexing)
+* [Index ERC721 and ERC-1155 NFTs on any EVM chain with an RPC URL](https://github.com/flair-sdk/examples/tree/main/erc721-and-erc1155-nft-indexing)
 
 ## Need help?
 

--- a/docs/build-on-linea/tooling/data-indexers/nftscan.md
+++ b/docs/build-on-linea/tooling/data-indexers/nftscan.md
@@ -17,7 +17,7 @@ This article provides information on how you can utilize the NFTScan API to moni
 
 # Understanding NFTScan
 
-NFTScan provides Web3 developers with the most professional, comprehensive and authoritative NFT data services and solutions. Through establishing the full NFT data information of multiple blockchain networks with standardized indexing methods, the NFTScan APIs help developers build new experiences retrieving NFTs. We provide a set of endpoints that enable you to fetch ERC721 and ERC1155 NFT assets as well as transactions, collections, marketplace statistics and more.
+NFTScan provides Web3 developers with the most professional, comprehensive and authoritative NFT data services and solutions. Through establishing the full NFT data information of multiple blockchain networks with standardized indexing methods, the NFTScan APIs help developers build new experiences retrieving NFTs. We provide a set of endpoints that enable you to fetch ERC-721 and ERC-1155 NFT assets as well as transactions, collections, marketplace statistics and more.
 
 # **What can NFTScan API provide**
 

--- a/docs/use-mainnet/bridges-of-linea/how-to-bridge-erc20-tokens.mdx
+++ b/docs/use-mainnet/bridges-of-linea/how-to-bridge-erc20-tokens.mdx
@@ -1,18 +1,23 @@
 ---
-title: How to bridge ERC20 tokens between Ethereum and Linea
+title: How to bridge ERC-20 tokens between Ethereum and Linea
 sidebar_position: 2
 ---
 
 :::note
 
-We recommend that only tech operators that are providing liquidity use our bridge for ERC20 tokens. For everyone else, check out [third-party bridges](/use-mainnet/bridges-of-linea#third-party-permissionless-bridges).
-**ERC20 tokens can only be bridged via [manual claiming](/use-mainnet/bridges-of-linea#manual-vs-automatic-claiming), which requires you to cover the ETH fee on the destination layer. Make sure your wallet is properly funded before beginning this process!**
+We recommend that only tech operators that are providing liquidity use the official Linea bridge to transfer ERC-20 tokens. 
 
-If you're bridging a token to Linea that hasn't been deployed before and you see a difference in the transferred token amount, don't worry – your tokens aren't lost. This could be a "[token bridge decimal mismatch](/use-mainnet/bridges-of-linea#what-is-token-bridge-decimal-mismatch)," which affects how the value is displayed. The chance of encountering this is quite low, but still good to know about.
+### For everyday bridge transfers, we recommend you use [MetaMask Portfolio's Bridge feature](https://portfolio.metamask.io/bridge), which aggregates bridging options across Linea and shows you the best rates.
 
-If you would like to bridge between other networks, check out [third-party bridges](/use-mainnet/bridges-of-linea#third-party-permissionless-bridges).
+For a closer look at the bridges that MetaMask Portfolio sources from, check out our information about [third-party bridges](/use-mainnet/bridges-of-linea#third-party-permissionless-bridges).
 
 :::
+
+### Transferring ERC-20 tokens via the official Linea bridge
+
+**ERC-20 tokens can only be bridged via [manual claiming](/use-mainnet/bridges-of-linea#manual-vs-automatic-claiming), which requires you to cover the ETH fee on the destination layer. Make sure your wallet is properly funded before beginning this process!**
+
+If you're bridging a token to Linea that hasn't been deployed before and you see a difference in the transferred token amount, don't worry – your tokens aren't lost. This could be a "[token bridge decimal mismatch](/use-mainnet/bridges-of-linea#what-is-token-bridge-decimal-mismatch)," which affects how the value is displayed. The chance of encountering this is quite low, but still good to know about.
 
 Check out the [tutorial](/use-mainnet/bridges-of-linea/how-to-bridge-eth) on how to bridge ETH to learn how to use our bridge and appropriately fund your wallet.
 

--- a/docs/use-mainnet/bridges-of-linea/how-to-bridge-eth.md
+++ b/docs/use-mainnet/bridges-of-linea/how-to-bridge-eth.md
@@ -3,13 +3,25 @@ title: How to bridge ETH between Ethereum and Linea
 sidebar_position: 1
 ---
 
+:::note
+
+We recommend that only tech operators that are providing liquidity use the official Linea bridge to transfer ETH. 
+
+### For everyday bridge transfers, we recommend you use [MetaMask Portfolio's Bridge feature](https://portfolio.metamask.io/bridge), which aggregates bridging options across Linea and shows you the best rates.
+
+For a closer look at the bridges that MetaMask Portfolio sources from, check out our information about [third-party bridges](/use-mainnet/bridges-of-linea#third-party-permissionless-bridges).
+
+:::
+
+### Transferring ETH via the official Linea bridge
+
 This is a step by step guide to bridging ETH between Ethereum Mainnet (L1) to Linea (L2).
 
 **To bridge ETH over testnet, simply click the testnet button at the bottom left of the [token bridge page](https://bridge.linea.build/) and follow the same steps as below.**
 
 If you would like to bridge between other networks, check out [third-party bridges](/use-mainnet/bridges-of-linea#third-party-permissionless-bridges).
 
-Check out this video on how to use our bridge!
+**Check out this video on how to use our bridge!**
 
 <iframe
   width="100%"

--- a/docs/use-mainnet/bridges-of-linea/index.mdx
+++ b/docs/use-mainnet/bridges-of-linea/index.mdx
@@ -28,7 +28,7 @@ We recommend you use the [official Linea token bridge](/use-mainnet/bridges-of-l
 
 **Bridge ERC-20 tokens**
 
-Again, we recommend the official bridge; ERC-20-specific instructions are [here](/use-mainnet/bridges-of-linea/how-to-bridge-ERC20-tokens).
+Again, we recommend the official bridge; ERC-20-specific instructions are [here](/use-mainnet/bridges-of-linea/how-to-bridge-erc20-tokens).
 
 ### Using ecosystem bridges
 

--- a/docs/use-mainnet/bridges-of-linea/index.mdx
+++ b/docs/use-mainnet/bridges-of-linea/index.mdx
@@ -15,7 +15,7 @@ Before you begin, make sure you've [set up your wallet](/use-mainnet/set-up-your
 >
 >The Linea ecosystem has a **growing and diverse number of bridges** operating on it. 
 >
->MetaMask Portfolio's Bridge feature **aggregates all those bridges**, and shows the options available to you so that you can **choose the provider and rate that you prefer**. Then, you can perform the bridging operation right from the dapp.
+>MetaMask Portfolio's Bridge feature leverages existing aggregators and individual bridges to show the options available to you so that you can **choose the provider and rate that you prefer**. Then, you can perform the bridging operation right from the dapp.
 
 **[Go to the Portfolio Bridge](https://portfolio.metamask.io/bridge)**
 

--- a/docs/use-mainnet/bridges-of-linea/index.mdx
+++ b/docs/use-mainnet/bridges-of-linea/index.mdx
@@ -7,17 +7,40 @@ sidebar_position: 3
 
 Before you begin, make sure you've [set up your wallet](/use-mainnet/set-up-your-wallet)
 
+
+
+### For all normal bridge traffic: 
+
+#### **We recommend you use the Bridge feature of MetaMask Portfolio: [https://portfolio.metamask.io/bridge](https://portfolio.metamask.io/bridge)**
+>
+>The Linea ecosystem has a **growing and diverse number of bridges** operating on it. 
+>
+>MetaMask Portfolio's Bridge feature **aggregates all those bridges**, and shows the options available to you so that you can **choose the provider and rate that you prefer**. Then, you can perform the bridging operation right from the dapp.
+
+**[Go to the Portfolio Bridge](https://portfolio.metamask.io/bridge)**
+
+
+### For dapp teams, liquidity providers, and technology operators moving large amounts of liquidity:
+
 **Bridge ETH**
-- [Use the official Linea token bridge](/use-mainnet/bridges-of-linea/how-to-bridge-eth) (for bridging between Linea and Ethereum)
-- [Use third party bridges](#third-party-permissionless-bridges) (for bridging between Ethereum, Linea, and other networks)
 
-**Bridge ERC20 tokens**
-- [Use the official Linea token bridge](/use-mainnet/bridges-of-linea/how-to-bridge-erc20-tokens) (recommended for tech operators that are providing liquidity)
-- [Use third party bridges](#third-party-permissionless-bridges) (for bridging between Ethereum, Linea, and other networks)
+We recommend you use the official Linea token bridge:(/use-mainnet/bridges-of-linea/how-to-bridge-eth) (for bridging between Linea and Ethereum)
 
-## The Linea bridge ecosystem
+**Bridge ERC-20 tokens**
 
-Any L2 is going to have a lot of connections to other networks. Some of these bridges will be made by Consensys and Linea, some by projects collaborating with us; eventually, some may be made without our knowledge—that’s what 'permissionless' means.
+Again, we recommend the official bridge; ERC-20-specific instructions are [here](/use-mainnet/bridges-of-linea/how-to-bridge-erc20-tokens).
+
+### Using ecosystem bridges
+
+As mentioned, MetaMask Portfolio's Bridge feature surveys bridges across Linea to source its routes and rates.
+
+For more information on those bridges and **how to move between Ethereum, Linea, and other networks**, please see [here](#third-party-permissionless-bridges).
+
+There are already a large number of ERC-20 tokens available for everyday use, as well as multi-chain transfers and functionality.
+
+## The Bridges of Linea
+
+Any L2 is going to have a lot of connections to other networks. Some of these bridges will be made by Consensys and Linea, some by projects collaborating with us; some may be made without our knowledge—that’s what 'permissionless' means.
 
 > ### What's going on here?
 >

--- a/docs/use-mainnet/bridges-of-linea/index.mdx
+++ b/docs/use-mainnet/bridges-of-linea/index.mdx
@@ -28,7 +28,7 @@ We recommend you use the official Linea token bridge:(/use-mainnet/bridges-of-li
 
 **Bridge ERC-20 tokens**
 
-Again, we recommend the official bridge; ERC-20-specific instructions are [here](/use-mainnet/bridges-of-linea/how-to-bridge-ERC-20-tokens).
+Again, we recommend the official bridge; ERC-20-specific instructions are [here](/use-mainnet/bridges-of-linea/how-to-bridge-ERC20-tokens).
 
 ### Using ecosystem bridges
 

--- a/docs/use-mainnet/bridges-of-linea/index.mdx
+++ b/docs/use-mainnet/bridges-of-linea/index.mdx
@@ -28,7 +28,7 @@ We recommend you use the official Linea token bridge:(/use-mainnet/bridges-of-li
 
 **Bridge ERC-20 tokens**
 
-Again, we recommend the official bridge; ERC-20-specific instructions are [here](/use-mainnet/bridges-of-linea/how-to-bridge-erc20-tokens).
+Again, we recommend the official bridge; ERC-20-specific instructions are [here](/use-mainnet/bridges-of-linea/how-to-bridge-ERC-20-tokens).
 
 ### Using ecosystem bridges
 
@@ -90,9 +90,9 @@ The anti-DDOS fee is only applied when bridging from L2 to L1 and is set to `0.0
 
 ## What is token bridge decimal mismatch?
 
-When a user bridges an ERC20 token from one chain to the other (e.g. Mainnet to Linea) and the token has not been deployed on the destination chain, the Token Bridge Smart Contract will attempt to determine the “decimals” of the ERC20 token. 
-If the "decimals" cannot be determined by reading the origin ERC20 token contract (e.g. a token contract does not adhere to the ERC20 standard https://ethereum.org/en/developers/docs/standards/tokens/erc-20/ ), it will default to 18 decimals. 
+When a user bridges an ERC-20 token from one chain to the other (e.g. Mainnet to Linea) and the token has not been deployed on the destination chain, the Token Bridge Smart Contract will attempt to determine the “decimals” of the ERC-20 token. 
+If the "decimals" cannot be determined by reading the origin ERC-20 token contract (e.g. a token contract does not adhere to the ERC-20 standard https://ethereum.org/en/developers/docs/standards/tokens/erc-20/ ), it will default to 18 decimals. 
 
-It's important to note that encountering this situation is uncommon, as most tokens with specified decimals usually adhere to the ERC20 standards.
+It's important to note that encountering this situation is uncommon, as most tokens with specified decimals usually adhere to the ERC-20 standards.
 
 Here's a simple example to help you understand what this means: if a token has 16 decimals on L1 but doesn't specify the decimals in token contract, then it defaults to 18 decimals on Linea due to missing information.  Bridging 1 token from L1 will show up as 0.01 on L2. When you bridge back the 0.01 to L1, it'll become 1 token again.

--- a/docs/use-mainnet/bridges-of-linea/index.mdx
+++ b/docs/use-mainnet/bridges-of-linea/index.mdx
@@ -24,7 +24,7 @@ Before you begin, make sure you've [set up your wallet](/use-mainnet/set-up-your
 
 **Bridge ETH**
 
-We recommend you use the official Linea token bridge:(/use-mainnet/bridges-of-linea/how-to-bridge-eth) (for bridging between Linea and Ethereum)
+We recommend you use the [official Linea token bridge](/use-mainnet/bridges-of-linea/how-to-bridge-eth) for bridging between Linea and Ethereum.
 
 **Bridge ERC-20 tokens**
 

--- a/static/files/testnet/TokenBridge.sol
+++ b/static/files/testnet/TokenBridge.sol
@@ -27,7 +27,7 @@ interface TokenBridge {
     Linea can pause the bridge for security reason. In this case new bridge transaction would revert.
 
   @notice This function is the single entry point to bridge tokens to the other chain, both for native and already bridged tokens.
-    You can use it to bridge any ERC20. If the token is bridged for the first time an ERC20 (BridgedToken.sol) will be automatically deployed on the target chain.
+    You can use it to bridge any ERC-20. If the token is bridged for the first time an ERC-20 (BridgedToken.sol) will be automatically deployed on the target chain.
 
     @param token The address of the token to be bridged.
     @param amount The amount of the token to be bridged.


### PR DESCRIPTION
Linea is now supported for bridging through MetaMask Portfolio.

This is going to be a powerful and convenient solution for everyday bridging purposes, greatly improving the UX of bridging between Linea and other networks.

Updating the official recommendations accordingly. The main changes are on three pages: 

/use-mainnet/bridges-of-linea
/use-mainnet/bridges-of-linea/how-to-bridge-eth
/how-to-bridge-erc20-tokens