### PR TITLE
Remove duplicate link check, eliminate failing checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    name: Lint Code Base, Spelling, Link Check
+    name: Lint Code Base, Spelling
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/project-words.txt
+++ b/project-words.txt
@@ -808,3 +808,5 @@ zpao
 zpaoAave
 zpaoAaveAave
 Lineabridge
+Briged
+chaind


### PR DESCRIPTION
I believe the issue we've been having with failing link checks is due to the fact that this GHA file was not correctly updated previously.

The linkchecker action, called further down, has a config file which... Ignores Docusaurus-style internal links.

The standard Link Check does not.

When the configured one was implemented, the Link Check function was removed.

