### PR TITLE
Fixing search text display colour for dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -433,7 +433,7 @@ html[data-theme="dark"] .header-dockerhub-link::before {
   --docsearch-searchbox-focus-background: var(--ifm-color-black);
   /* Hit */
   --docsearch-hit-color: var(--ifm-font-color-base);
-  --docsearch-hit-active-color: var(--ifm-color-white);
+  --docsearch-hit-active-color: var(--ifm-color-black);
   --docsearch-hit-background: var(--ifm-color-emphasis-100);
   /* Footer */
   --docsearch-footer-background: var(--ifm-background-surface-color);


### PR DESCRIPTION
changed dark mode search result text to black when hovering, so that it's now visible against the white background.