### PR TITLE
fixing callout. Argh.

### DIFF
--- a/docs/build-on-linea/linea-version/index.mdx
+++ b/docs/build-on-linea/linea-version/index.mdx
@@ -72,7 +72,8 @@ To decrease L1 costs, we implemented the following features:
   - The calldata will contain only the final block state root hash and final block number.
 
 :::info
-[Note] This is a breaking change for consumers listening to the existing events. The `BlockFinalized` event will be replaced by the `DataFinalized` event. :::
+[Note] This is a breaking change for consumers listening to the existing events. The `BlockFinalized` event will be replaced by the `DataFinalized` event. 
+:::
 
 <table>
   <tbody>


### PR DESCRIPTION
Callout was improperly formatted on Release Notes page. Too much green.