### PR TITLE
Fix syntax error on note

### DIFF
--- a/docs/use-mainnet/bridges-of-linea/index.mdx
+++ b/docs/use-mainnet/bridges-of-linea/index.mdx
@@ -41,7 +41,8 @@ If you are interested in this option, please contact the Linea team to get start
 - Linea team will configure the bridge so that it will use your custom contract to mint and burn tokens on L2.
 
 :::note
- If you are not yet ready with your own implementation, you can deploy the standard BridgedToken implementation behind a dedicated upgradable proxy that you will be able to upgrade later :::
+ If you are not yet ready with your own implementation, you can deploy the standard BridgedToken implementation behind a dedicated upgradable proxy that you will be able to upgrade later.
+:::
 
 ### 3. Build a dedicated token bridge
 


### PR DESCRIPTION
This note callout box has a syntax error on [this page](https://docs.linea.build/use-mainnet/bridges-of-linea)
<img width="977" alt="Screenshot 2024-02-23 at 3 04 33 PM" src="https://github.com/Consensys/doc.zk-evm/assets/5498502/d91196f0-b79b-4675-ac40-a0163b38b6a9">
