### PR TITLE
Replace LXP info link

### DIFF
--- a/docs/use-mainnet/linea-xp.mdx
+++ b/docs/use-mainnet/linea-xp.mdx
@@ -7,11 +7,11 @@ sidebar_position: 5
 
 Similar to video games, where your character can gain experience points (XP) as you go through the game, Voyage XP represents your journey and experience in the Linea ecosystem. The Voyage XP tokens will be a custom version of ERC-20 and will be visible by default in your MetaMask wallet.
 
-**Voyage XP tokens are non-transferrable, soulbound tokens that are distributed to recognize the community’s extraordinary contribution toward the growth of the Linea ecosystem. They do not have any monetary value!**
+**Voyage XP tokens are non-transferrable, soulbound tokens that are distributed to recognize the community's extraordinary contribution toward the growth of the Linea ecosystem. They do not have any monetary value!**
 
 Apart from being a measure of contribution to building Linea into a robust and secure L2 network, Voyage XP will also make owners eligible for benefits such as receiving official community roles, exclusive Linea swag, and more!
 
-To learn more about the Linea Voyage XP Program click [here](https://linea.mirror.xyz/sl3dN6bP3h0Uxhh5yA_jqy9UFayjqCeChRvOSi1U3B8)
+To learn more about the Linea Voyage XP Program click [here](https://support.linea.build/hc/articles/20985380911771)
 
 :::note
 Voyage XP are non-transferable and not bridgeable to other networks. You cannot buy, sell, or swap them, nor can you accumulate them by transferring from another wallet.


### PR DESCRIPTION
The article previously linked out to a Mirror article; since this page is end user-focussed, we decided to swap this for the support page's [LXP FAQ](https://support.linea.build/hc/en-us/articles/20985380911771-Linea-Voyage-XP-tokens-LXP-FAQs) instead.