### PR TITLE
Update Card text color on hover.

### DIFF
--- a/src/components/HomepageCards/styles.module.css
+++ b/src/components/HomepageCards/styles.module.css
@@ -77,4 +77,5 @@
   box-shadow: 0 0 10px rgb(97 223 255 / 50%);
   border: none;
   transform: scale(1.02);
+  color: #1d1d1d
 }


### PR DESCRIPTION
Text in the quick link buttons on the home page are currently hidden when the user hovers. Updated the text color on hover to ensure it displays.