### PR TITLE
Update code formatting.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -206,7 +206,14 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ["solidity", "toml", "bash", "json", "typescript", "javascript"],
+        additionalLanguages: [
+          "solidity",
+          "toml",
+          "bash",
+          "json",
+          "typescript",
+          "javascript",
+        ],
       },
       languageTabs: [
         {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -213,6 +213,7 @@ const config = {
           "json",
           "typescript",
           "javascript",
+          "python",
         ],
       },
       languageTabs: [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -206,7 +206,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
-        additionalLanguages: ["solidity", "toml"],
+        additionalLanguages: ["solidity", "toml", "bash", "json", "typescript", "javascript"],
       },
       languageTabs: [
         {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -263,8 +263,8 @@ code,
 kbd,
 pre,
 samp {
-  font-family: inherit;
-  font-size: 1em;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--ifm-code-font-size);
 }
 
 small {


### PR DESCRIPTION
Updated the `prism` object to include additional languages (for code highlighting). Used a monospace font for code.
Fixes #433 