### PR TITLE
Update token contract info page

### DIFF
--- a/docs/use-mainnet/info-contracts.mdx
+++ b/docs/use-mainnet/info-contracts.mdx
@@ -127,68 +127,19 @@ We recommend connecting to Linea via [private RPCs](../build-on-linea/tooling/no
 <Tabs groupId="Mainnet-Testnet" className="my-tabs">
   <TabItem value="Mainnet" label="Mainnet" default>
 
-To see **the most up to date list of tokens on Linea**, see [the token explorer here](https://consensys.github.io/linea-token-list/).
+To see **the most up to date list of tokens on Linea**, see [the token explorer here](https://consensys.github.io/linea-token-list/), which is derived from the official lists in [this repo](https://github.com/Consensys/linea-token-list/blob/main/json/linea-mainnet-token-shortlist.json). 
+
+:::warning[Note]
+
+We recommend you rely on the shortlist in the above links, rather than the full list. The shortlist is actively curated by our team, whereas the full list is not, and automatically populates with all tokens bridged to Linea. 
+
+:::
 
 To **get your own token included**, please follow the instructions on this [repository](https://github.com/Consensys/linea-token-list).
 
 To see **which third-party bridges are available**, consult our [Ecosystem Portal's list](https://linea.build/apps?types=bridge).
 
 If you're **looking to bridge tokens to or from Linea**, you can do so easily in **MetaMask Portfolio's Bridge feature**: [https://portfolio.metamask.io/bridge](https://portfolio.metamask.io/bridge)
-
-| Token | Ethereum Address | Linea Address |
-| ----- | ---------------- | ------------- |
-| agEUR | [0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8](https://etherscan.io/address/0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8) | [0xdeE96799De4eF546C552FaDb765AAF7a18C6a8D6](https://lineascan.build/address/0xdeE96799De4eF546C552FaDb765AAF7a18C6a8D6) |
-| ALT | [0xC1e2A416ea16d2d7FDc8Ff0890C60109a262A176](https://etherscan.io/address/0xC1e2A416ea16d2d7FDc8Ff0890C60109a262A176) | [0xe0f0035FFaba23872AC4D7F2240c0b5265a000f1](https://lineascan.build/address/0xe0f0035FFaba23872AC4D7F2240c0b5265a000f1) |
-| Angle Protocol | [0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8](https://etherscan.io/address/0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8) | [0x1578f35532FA091EcED8638730F9dB829930ce16](https://lineascan.build/address/0x1578f35532FA091EcED8638730F9dB829930ce16) |
-| Ankr Staked ETH | [0xE95A203B1a91a908F9B9CE46459d101078c2c3cb](https://etherscan.io/address/0xE95A203B1a91a908F9B9CE46459d101078c2c3cb) | [0xff8069906C1BdD7650c889f54639a5fcE486ca3e](https://lineascan.build/address/0xff8069906C1BdD7650c889f54639a5fcE486ca3e) |
-| ApeCoin | [0x4d224452801aced8b2f0aebe155379bb5d594381](https://etherscan.io/address/0x4d224452801aced8b2f0aebe155379bb5d594381) | [0x6bAA318CF7C51C76e17ae1EbE9Bbff96AE017aCB](https://lineascan.build/address/0x6bAA318CF7C51C76e17ae1EbE9Bbff96AE017aCB) |
-| Balancer | [0xba100000625a3754423978a60c9317c58a424e3D](https://etherscan.io/address/0xba100000625a3754423978a60c9317c58a424e3D) | [0x660edb0A46c3f69be9eFF5446318593b9469F9e2](https://lineascan.build/address/0x660edb0A46c3f69be9eFF5446318593b9469F9e2) |
-| ChainLink Token | [0x514910771af9ca656af840dff83e8264ecf986ca](https://etherscan.io/address/0x514910771af9ca656af840dff83e8264ecf986ca) | [0x5B16228B94b68C7cE33AF2ACc5663eBdE4dCFA2d](https://lineascan.build/address/0x5B16228B94b68C7cE33AF2ACc5663eBdE4dCFA2d) |
-| Dai Stablecoin | [0x6b175474e89094c44da98b954eedeac495271d0f](https://etherscan.io/address/0x6b175474e89094c44da98b954eedeac495271d0f) | [0x4AF15ec2A0BD43Db75dd04E62FAA3B8EF36b00d5](https://lineascan.build/address/0x4AF15ec2A0BD43Db75dd04E62FAA3B8EF36b00d5) |
-| Deri | [0xA487bF43cF3b10dffc97A9A744cbB7036965d3b9](https://etherscan.io/address/0xA487bF43cF3b10dffc97A9A744cbB7036965d3b9) | [0x4aCde18aCDE7F195E6Fb928E15Dc8D83D67c1f3A](https://lineascan.build/address/0x4aCde18aCDE7F195E6Fb928E15Dc8D83D67c1f3A) |
-| DeversiFi Token | [0xdddddd4301a082e62e84e43f474f044423921918](https://etherscan.io/address/0xdddddd4301a082e62e84e43f474f044423921918) | [0x1f031f8c523b339c7a831355879e3568fa3eb263](https://lineascan.build/address/0x1f031f8c523b339c7a831355879e3568fa3eb263) |
-| DSLA Protocol | [0x3aFfCCa64c2A6f4e3B6Bd9c64CD2C969EFd1ECBe](https://etherscan.io/address/0x3aFfCCa64c2A6f4e3B6Bd9c64CD2C969EFd1ECBe) | [0x70359c1eeB98eb3D12eE7178359a4541ff11Cc8E](https://lineascan.build/address/0x70359c1eeB98eb3D12eE7178359a4541ff11Cc8E) |
-| Frax Share | [0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0](https://etherscan.io/address/0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0) | [0x0A79e44c99505c7f388CA30c787ff97217E73ecC](https://lineascan.build/address/0x0A79e44c99505c7f388CA30c787ff97217E73ecC) |
-| Gitcoin | [0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F](https://etherscan.io/address/0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F) | [0x762E2cbf28752B8750AbCEf1C37e99989331025e](https://lineascan.build/address/0x762E2cbf28752B8750AbCEf1C37e99989331025e) |
-| Gnosis Token | [0x6810e776880C02933D47DB1b9fc05908e5386b96](https://etherscan.io/address/0x6810e776880C02933D47DB1b9fc05908e5386b96) | [0xe516a5CFf996cc399EFBb48355FD5Ab83438E7a9](https://lineascan.build/address/0xe516a5CFf996cc399EFBb48355FD5Ab83438E7a9) |
-| Gravita Debt Token | [0x15f74458aE0bFdAA1a96CA1aa779D715Cc1Eefe4](https://etherscan.io/address/0x15f74458aE0bFdAA1a96CA1aa779D715Cc1Eefe4) |[0x894134a25a5faC1c2C26F1d8fBf05111a3CB9487](https://lineascan.build/address/0x894134a25a5faC1c2C26F1d8fBf05111a3CB9487)  |
-| HAPI Protocol | [0xd9c2d319cd7e6177336b0a9c93c21cb48d84fb54](https://etherscan.io/address/0xd9c2d319cd7e6177336b0a9c93c21cb48d84fb54) | [0x0e5F2ee8C29e7eBc14e45dA7FF90566d8c407dB7](https://lineascan.build/address/0x0e5F2ee8C29e7eBc14e45dA7FF90566d8c407dB7) |
-| izumi Token | [0x9ad37205d608B8b219e6a2573f922094CEc5c200](https://etherscan.io/address/0x9ad37205d608B8b219e6a2573f922094CEc5c200) | [0xa5d4117511938c71615d5b714B7E58c04C112D16](https://lineascan.build/address/0xa5d4117511938c71615d5b714B7E58c04C112D16) |
-| Kyber Network Crystal v2 | [0xdeFA4e8a7bcBA345F687a2f1456F5Edd9CE97202](https://etherscan.io/address/0xdeFA4e8a7bcBA345F687a2f1456F5Edd9CE97202) | [0x3b2F62d42DB19B30588648bf1c184865D4C3B1D6](https://lineascan.build/address/0x3b2F62d42DB19B30588648bf1c184865D4C3B1D6) |
-| Lido DAO Token | [0x5a98fcbea516cf06857215779fd812ca3bef1b32](https://etherscan.io/address/0x5a98fcbea516cf06857215779fd812ca3bef1b32) | [0x0e076AAFd86a71dCEAC65508DAF975425c9D0cB6](https://lineascan.build/address/0x0e076AAFd86a71dCEAC65508DAF975425c9D0cB6) |
-| Linea XP | N/A | [0xd83af4fbd77f3ab65c3b1dc4b38d7e67aecf599a](https://lineascan.build/address/0xd83af4fbd77f3ab65c3b1dc4b38d7e67aecf599a) |
-| Linear Token | [0x3E9BC21C9b189C09dF3eF1B824798658d5011937](https://etherscan.io/address/0x3E9BC21C9b189C09dF3eF1B824798658d5011937) | [0x974aFBd15Ad987dB9336F4Ac10d35a4FF32e31C5](https://lineascan.build/address/0x974aFBd15Ad987dB9336F4Ac10d35a4FF32e31C5) |
-| LUBE | N/A | [0x1bE3735Dd0C0Eb229fB11094B6c277192349EBbf](https://lineascan.build/address/0x1bE3735Dd0C0Eb229fB11094B6c277192349EBbf) |
-| Lybra Finance | [0xF1182229B71E79E504b1d2bF076C15a277311e05](https://etherscan.io/address/0xF1182229B71E79E504b1d2bF076C15a277311e05) | [0x9D36f49D3d42B3A9BcC0f5Ac76fF8ef78fB2bC01](https://lineascan.build/address/0x9D36f49D3d42B3A9BcC0f5Ac76fF8ef78fB2bC01) |
-| Mai Stablecoin | N/A | [0xf3B001D64C656e30a62fbaacA003B1336b4ce12A](https://lineascan.build/address/0xf3B001D64C656e30a62fbaacA003B1336b4ce12A) |
-| Maker | [0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2](https://etherscan.io/address/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2) | [0x2442Bd7AE83b51F6664De408A385375fe4a84F52](https://lineascan.build/address/0x2442Bd7AE83b51F6664De408A385375fe4a84F52) |
-| Matic Token | [0x265B25e22bcd7f10a5bD6E6410F10537Cc7567e8](https://etherscan.io/address/0x265B25e22bcd7f10a5bD6E6410F10537Cc7567e8) | [0x6dD9763aA23E03aEc9A8e5c4d8a735E168a6D3c5](https://lineascan.build/address/0x6dD9763aA23E03aEc9A8e5c4d8a735E168a6D3c5) |
-| Matic Token | [0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0](https://etherscan.io/address/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0) | [0xe742f157d65355d51c6Df82f04A703F3081c3e81](https://lineascan.build/address/0xe742f157d65355d51c6Df82f04A703F3081c3e81) |
-| Meta Apes Peel | [0x1ed81e03d7ddb67a21755d02ed2f24da71c27c55](https://etherscan.io/address/0x1ed81e03d7ddb67a21755d02ed2f24da71c27c55) | [0xA6eb75B11b36FB9175fB94C5b96959879A26C2A8](https://lineascan.build/address/0xA6eb75B11b36FB9175fB94C5b96959879A26C2A8) |
-| MetalSwap | [0x3E5D9D8a63CC8a88748f229999CF59487e90721e](https://etherscan.io/address/0x3E5D9D8a63CC8a88748f229999CF59487e90721e) | [0x3E5D9D8a63CC8a88748f229999CF59487e90721e](https://lineascan.build/address/0x3E5D9D8a63CC8a88748f229999CF59487e90721e) |
-| Pax Dollar | [0x8E870D67F660D95d5be530380D0eC0bd388289E1](https://etherscan.io/address/0x8E870D67F660D95d5be530380D0eC0bd388289E1) | [0xd2bc272EA0154A93bf00191c8a1DB23E67643EC5](https://lineascan.build/address/0xd2bc272EA0154A93bf00191c8a1DB23E67643EC5) |
-| Pepe | [0x6982508145454ce325ddbe47a25d4ec3d2311933](https://etherscan.io/address/0x6982508145454ce325ddbe47a25d4ec3d2311933) | [0x7da14988E4f390C2E34ed41DF1814467D3aDe0c3](https://lineascan.build/address/0x7da14988E4f390C2E34ed41DF1814467D3aDe0c3) |
-| ScamFari | [0x8353b92201f19B4812EeE32EFd325f7EDe123718](https://etherscan.io/address/0x8353b92201f19B4812EeE32EFd325f7EDe123718) | [0x13a7f090d46c74acba98c51786a5c46ed9a474f0](https://lineascan.build/address/0x13a7f090d46c74acba98c51786a5c46ed9a474f0) |
-| SENET | [0xC309aB7b475A9B2292b1060E0EDf7D158cdddB07](https://etherscan.io/address/0xC309aB7b475A9B2292b1060E0EDf7D158cdddB07) | [0x663B43Bd9aC6E45461A73b2115eEFd7278383f20](https://lineascan.build/address/0x663B43Bd9aC6E45461A73b2115eEFd7278383f20) |
-| SHIBA INU | [0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce](https://etherscan.io/address/0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce) | [0x99AD925C1Dc14Ac7cc6ca1244eeF8043C74E99d5](https://lineascan.build/address/0x99AD925C1Dc14Ac7cc6ca1244eeF8043C74E99d5) |
-| SIDUS | [0x549020a9Cb845220D66d3E9c6D9F9eF61C981102](https://etherscan.io/address/0x549020a9Cb845220D66d3E9c6D9F9eF61C981102) | [0x536e731a8Ae166173D8875Ad55567B00F264b7b4](https://lineascan.build/address/0x536e731a8Ae166173D8875Ad55567B00F264b7b4) |
-| SOCURE | [0x540E6FE50A07579968eC37e77f15BEC8DbdB79D9](https://etherscan.io/address/0x540E6FE50A07579968eC37e77f15BEC8DbdB79D9) | [0xb6489De309cb0b37fce5821D99F7300451eE6F68](https://lineascan.build/address/0xb6489De309cb0b37fce5821D99F7300451eE6F68) |
-| Stone Liquidity Ether Token | N/A | [0x93F4d0ab6a8B4271f4a28Db399b5E30612D21116](https://lineascan.build/address/0x93F4d0ab6a8B4271f4a28Db399b5E30612D21116) |
-| Symbiosis | [0xd38BB40815d2B0c2d2c866e0c72c5728ffC76dd9](https://etherscan.io/address/0xd38BB40815d2B0c2d2c866e0c72c5728ffC76dd9) | [0x6EF95B6f3b0F39508e3E04054Be96D5eE39eDE0d](https://lineascan.build/address/0x6EF95B6f3b0F39508e3E04054Be96D5eE39eDE0d) |
-| Tether USD | [0xdac17f958d2ee523a2206206994597c13d831ec7](https://etherscan.io/address/0xdac17f958d2ee523a2206206994597c13d831ec7) | [0xA219439258ca9da29E9Cc4cE5596924745e12B93](https://lineascan.build/address/0xA219439258ca9da29E9Cc4cE5596924745e12B93) |
-| THORChain ETH.RUNE | [0x3155BA85D5F96b2d030a4966AF206230e46849cb](https://etherscan.io/address/0x3155BA85D5F96b2d030a4966AF206230e46849cb) | [0xe322E20738386766F769b0a6083f4141083d26d0](https://lineascan.build/address/0xe322E20738386766F769b0a6083f4141083d26d0) |
-| Uniswap | [0x1f9840a85d5af5bf1d1762f925bdaddc4201f984](https://etherscan.io/address/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984) | [0x636B22bC471c955A8DB60f28D4795066a8201fa3](https://lineascan.build/address/0x636B22bC471c955A8DB60f28D4795066a8201fa3) |
-| US KUMA Interest Bearing Token | N/A | [0xC84f2ce21272f17d92d2a450F1C8567bF0ff448E](https://lineascan.build/address/0xC84f2ce21272f17d92d2a450F1C8567bF0ff448E) |
-| USDC | [0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48](https://etherscan.io/address/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) | [0x176211869cA2b568f2A7D4EE941E073a821EE1ff](https://lineascan.build/address/0x176211869cA2b568f2A7D4EE941E073a821EE1ff) |
-| USD+ | N/A | [0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376](https://lineascan.build/address/0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376) |
-| USDLR by Stable | [0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917](https://etherscan.io/address/0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917) | [0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917](https://lineascan.build/address/0x68592c5c98c4f4a8a4bc6da2121e65da3d1c0917) |
-| USDT+ | N/A | [0x1E1F509963A6D33e169D9497b11c7DbFe73B7F13](https://lineascan.build/address/0x1E1F509963A6D33e169D9497b11c7DbFe73B7F13) |
-| Velocore LP: SCM + ETH | [0xd4e9b2e8d6B360980A3a75a3C69B3C3040a89008](https://etherscan.io/address/0xd4e9b2e8d6B360980A3a75a3C69B3C3040a89008) | [0x6729659F4D81DdbD6Ac48ddDA9C5D62c01081B5D](https://lineascan.build/address/0x6729659F4D81DdbD6Ac48ddDA9C5D62c01081B5D) |
-| Wrapped BTC | [0x2260fac5e5542a773aa44fbcfedf7c193bc2c599](https://etherscan.io/address/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599) | [0x3aAB2285ddcDdaD8edf438C1bAB47e1a9D05a9b4](https://lineascan.build/address/0x3aAB2285ddcDdaD8edf438C1bAB47e1a9D05a9b4) |
-| Wrapped Ether | N/A | [0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f](https://lineascan.build/address/0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f) |
-| Wrapped liquid staked Ether 2.0 | [0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0](https://etherscan.io/address/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0) | [0xB5beDd42000b71FddE22D3eE8a79Bd49A568fC8F](https://lineascan.build/address/0xB5beDd42000b71FddE22D3eE8a79Bd49A568fC8F) |
-| XFai | [0x4aa41bC1649C9C3177eD16CaaA11482295fC7441](https://etherscan.io/address/0x4aa41bC1649C9C3177eD16CaaA11482295fC7441) | [0x8C56017B172226fE024dEa197748FC1eaccC82B1](https://lineascan.build/address/0x8C56017B172226fE024dEa197748FC1eaccC82B1) |
-| Yellow Duckies | [0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320](https://etherscan.io/address/0x90b7E285ab6cf4e3A2487669dba3E339dB8a3320) | [0x796000FAd0d00B003B9dd8e531BA90cff39E01E0](https://lineascan.build/address/0x796000FAd0d00B003B9dd8e531BA90cff39E01E0) |
 
   </TabItem>
   <TabItem value="Testnet" label="Testnet">


### PR DESCRIPTION
- Remove table that displayed all tokens in the longlist [here](https://github.com/Consensys/linea-token-list/blob/main/json/linea-mainnet-token-fulllist.json)
- Place additional focus on the [token explorer site](https://consensys.github.io/linea-token-list/) and the shortlist in the repo
- Add callout recommending that users stick to the tokens in the shortlist, which is actively curated.