### PR TITLE
Add callouts regarding temporary behaviour of `linea_estimateGas`

### DIFF
--- a/docs/build-on-linea/gas-fees.mdx
+++ b/docs/build-on-linea/gas-fees.mdx
@@ -37,6 +37,13 @@ call provides an estimate that includes the layer 1 and layer 2 fees.
 
 ## Calculate transaction fees
 
+:::note
+
+`linea_estimateGas` is currently being rolled out, and will temporarily provide results similar 
+to `eth_gasPrice`.
+
+:::
+
 Use the [`linea_estimateGas`](../reference/api/linea-estimategas.mdx) API method to estimate the gas cost for sending a
 transaction. The method returns the recommended gas limit, the base fee per gas, and the priority fee per gas.
 

--- a/docs/reference/api/linea-estimategas.mdx
+++ b/docs/reference/api/linea-estimategas.mdx
@@ -10,6 +10,15 @@ import TabItem from '@theme/TabItem';
 Generates and returns an estimate of how much gas is necessary to allow the transaction to complete and be published on Ethereum.
 The transaction will not be added to the blockchain.
 
+:::tip[Rollout in progress]
+
+Although `linea_estimateGas` is available to use, it is still in rollout. At the moment, it will 
+return a similar result to `eth_gasPrice`. 
+
+We will update this page when this is no longer the case.
+
+:::
+
 For more information about estimating gas, and how this API formulates the transaction costs, see the
 [Estimate transaction costs](../../build-on-linea/gas-fees.mdx) topic.
 


### PR DESCRIPTION
`linea_estimateGas` is currently still being rolled out and does not provide the expected results when called, but rather results similar to those that `eth_gasPrice`. Added callouts in two relevant locations to make this clear. 