### PR TITLE
Add Alpha v3 release notes

### DIFF
--- a/docs/build-on-linea/linea-version/index.mdx
+++ b/docs/build-on-linea/linea-version/index.mdx
@@ -11,6 +11,47 @@ import TokenBridgeL2 from "!!raw-loader!/files/testnet/2023-06-13-release/TokenB
 
 Find out all you need to know about the latest Linea versions.
 
+## Alpha v3 release notes
+
+### Summary
+
+The main objective of Alpha v3 is to implement EIP-4844 on Linea, following its introduction to 
+Ethereum mainnet with the Dencun upgrade on March 13.
+
+### Features
+
+#### March 26: EIP-4844
+
+Begin using blob data to post data to L1, significantly reducing data availability costs. 
+Blob data replaces `calldata` and is significantly cheaper.
+
+Multiple contracts have been updated and support blob data. Notable new contract addresses include:
+
+- New verifier contract
+  - Linea Sepolia: [0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79](https://sepolia.lineascan.build/address/0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79)
+  - Linea mainnet: TBC
+- New L1 message service
+  - Linea Sepolia: [0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5](https://sepolia.lineascan.build/address/0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5)
+  - Linea mainnet: TBC
+- New L2 rollup contract
+  - Linea Sepolia: [0x971e727e956690b9957be6d51Ec16E73AcAC83A7](https://sepolia.lineascan.build/address/0x971e727e956690b9957be6d51Ec16E73AcAC83A7)
+  - Linea mainnet: TBC
+
+All contracts have been audited by OpenZeppelin. A link to their reports will be shared here once
+available.
+
+#### March 27
+
+- Block time reduced to 3 seconds. This change aims to improve user experience by increasing
+the network's tps (transactions per second) capacity.
+- Gas fee reductions. After EIP-4844 is implemented on March 26, we will gather data for 24 hours
+to develop a fuller understanding of the implications for gas fees. Reduced gas fees will then be 
+available to users on March 27. 
+
+### Breaking changes
+
+None.
+
 ## February 2024
 
 ### February 19

--- a/docs/build-on-linea/linea-version/index.mdx
+++ b/docs/build-on-linea/linea-version/index.mdx
@@ -20,30 +20,34 @@ Ethereum mainnet with the Dencun upgrade on March 13.
 
 ### Features
 
-#### March 26: EIP-4844
+**March 26: EIP-4844**
 
-Begin using blob data to post data to L1, significantly reducing data availability costs. 
-Blob data replaces `calldata` and is significantly cheaper.
+Begin using blobs to post compressed L2 data to L1, with the aim of reducing data availability
+costs. Blobs represent a transient data storage mechanism and an alternative to `calldata`, and
+can be significantly cheaper in L1 ETH costs depending on market demand.
 
-Multiple contracts have been updated and support blob data. Notable new contract addresses include:
+L1 and L2 smart contracts have been updated and deployed for Alpha v3. The contract addresses are:
 
 - New verifier contract
   - Linea Sepolia: [0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79](https://sepolia.lineascan.build/address/0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79)
-  - Linea mainnet: TBC
+  - Linea Mainnet: TBC
 - New L1 message service
   - Linea Sepolia: [0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5](https://sepolia.lineascan.build/address/0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5)
-  - Linea mainnet: TBC
+  - Linea Mainnet: TBC
 - New L2 rollup contract
   - Linea Sepolia: [0x971e727e956690b9957be6d51Ec16E73AcAC83A7](https://sepolia.lineascan.build/address/0x971e727e956690b9957be6d51Ec16E73AcAC83A7)
-  - Linea mainnet: TBC
+  - Linea Mainnet: TBC
 
-All contracts have been audited by OpenZeppelin. A link to their reports will be shared here once
-available.
+Smart contract updates will be executed by the Linea Security Council using the Safe multi-sig 
+procedure. 
 
-#### March 27
+Additionally, all contracts have been audited by OpenZeppelin. A link to their reports will be 
+shared here once available.
 
-- Block time reduced to 3 seconds. This change aims to improve user experience by increasing
-the network's tps (transactions per second) capacity.
+**March 27**
+
+- Block time reduced to 3 seconds. This change increases the throughput of the network to avoid
+any potential L2 execution bottlenecks from increased Linea activity.
 - Gas fee reductions. After EIP-4844 is implemented on March 26, we will gather data for 24 hours
 to develop a fuller understanding of the implications for gas fees. Reduced gas fees will then be 
 available to users on March 27. 


### PR DESCRIPTION
This PR adds the main, relevant updates to Linea for the Alpha v3 release to the [release notes page](https://docs.linea.build/build-on-linea/linea-version). 