### PR TITLE
Update node volume size details

### DIFF
--- a/docs/build-on-linea/run-a-node/use-binary.mdx
+++ b/docs/build-on-linea/run-a-node/use-binary.mdx
@@ -115,8 +115,14 @@ Download the genesis file for the relevant network.
 
 ### Step 3. Define disk space volume (optional)
 
-Define a volume of at least `100GB`, more if you want to future-proof your node, and mount the Geth `datadir` to the
-custom volume.
+Define a volume size appropriate to your expected usage. As of March 20, Besu nodes use:
+
+- Full nodes: 170GB, growing ~2.6GB per day.
+- Archive nodes: 760GB, growing ~10GB per day.
+
+Use these figures as a basis to determine the extent to which you want to future-proof your node.
+
+Ensure you mount the Geth `datadir` to the custom volume.
 
 If you run out of space, or need to actively maintain how much space is being used, consider
 [pruning](https://geth.ethereum.org/docs/fundamentals/pruning).

--- a/docs/build-on-linea/run-a-node/use-binary.mdx
+++ b/docs/build-on-linea/run-a-node/use-binary.mdx
@@ -49,8 +49,8 @@ Download the genesis file and Besu configuration file.
 
 Define a volume size appropriate to your expected usage. As of March 20, Besu nodes use:
 
-- Full nodes: 120GB, growing ~1.5GB per day (depending on whether you use pruning, and the storage
-method)
+- Full nodes: 120GB, growing ~1.5GB per day (depending on whether you use [pruning](https://besu.hyperledger.org/23.4.0/public-networks/concepts/data-storage-formats#pruning), 
+and the storage method)
 - Archive nodes: 740GB, growing ~9.5GB per day.
 
 Use these figures as a basis to determine the extent to which you want to future-proof your node.

--- a/docs/build-on-linea/run-a-node/use-binary.mdx
+++ b/docs/build-on-linea/run-a-node/use-binary.mdx
@@ -47,8 +47,15 @@ Download the genesis file and Besu configuration file.
 
 ### Step 3. Define disk space volume (optional)
 
-Define a volume of at least `100GB`, more if you want to future-proof your node, and mount the Besu `data-path` to the
-custom volume when you [start the node].
+Define a volume size appropriate to your expected usage. As of March 20, Besu nodes use:
+
+- Full nodes: 120GB, growing ~1.5GB per day (depending on whether you use pruning, and the storage
+method)
+- Archive nodes: 740GB, growing ~9.5GB per day.
+
+Use these figures as a basis to determine the extent to which you want to future-proof your node.
+
+Ensure you mount the Besu `data-path` to the custom volume when you start the node.
 
 <VolumeCreation />
 


### PR DESCRIPTION
This PR adds some details around how large a node runner should define the disk space for running a node. Rather than specifying a value, we now provide users with up-to-date info on how much space nodes currently require, and their anticipated growth. 