### PR TITLE
Add further details to Sepolia transition page

### DIFF
--- a/docs/build-on-linea/goerli-to-sepolia.mdx
+++ b/docs/build-on-linea/goerli-to-sepolia.mdx
@@ -34,7 +34,7 @@ For your dapp to remain functional, you must:
 
 ## Linea Sepolia network details
 
-You can find a more thorough overview of key Linea Sepolia details on our [network info page](use-mainnet/info-contracts). 
+You can find a more thorough overview of key Linea Sepolia details on our [network info page](/use-mainnet/info-contracts). 
 
 Here are the key details:
 

--- a/docs/build-on-linea/goerli-to-sepolia.mdx
+++ b/docs/build-on-linea/goerli-to-sepolia.mdx
@@ -44,3 +44,58 @@ Here are the key details:
     - [Lineascan](https://sepolia.lineascan.build)
     - [Blockscout](https://explorer.sepolia.linea.build)
 - Symbol: ETH
+
+## Infura endpoint
+
+An Infura endpoint (https://rpc.sepolia.linea.build) for Linea Sepolia will be functional from 
+March 25.
+
+## MetaMask integration
+
+Linea Sepolia will replace Linea Goerli as one of the pre-loaded testnets available in MetaMask:
+
+- MetaMask Extension: 11.13.1 — likely to be available from March 29.
+- MetaMask Mobile: 7.19.0 — likely to be available from April 1.
+
+## Libraries, integrations, and tooling
+
+### Safe
+
+Support for Linea Sepolia will be added to [safe.linea.build](https://safe.linea.build/welcome) 
+soon.
+
+### Libraries
+
+The following libraries already support Linea Sepolia:
+
+- Ethereum-lists
+- WalletConnect
+- Ethers.js 
+- ApeWorx
+- Chainlist
+- Multicall3
+
+The following libraries do not yet support Linea Sepolia:
+
+- Wagmi
+- WETH9
+
+### Bridge
+
+The official [Linea bridge](https://bridge.linea.build/) already supports Linea Sepolia.
+
+### Faucets
+
+Live: 
+- [Covalent](https://www.covalenthq.com/faucet/)
+
+Coming soon:
+- [Infura](https://www.infura.io/faucet/linea)
+- XMTP
+- [LearnWeb3](https://learnweb3.io/faucets/)
+
+### Other
+
+In progress:
+- ENS support
+- WETH9

--- a/docs/build-on-linea/goerli-to-sepolia.mdx
+++ b/docs/build-on-linea/goerli-to-sepolia.mdx
@@ -61,8 +61,8 @@ Linea Sepolia will replace Linea Goerli as one of the pre-loaded testnets availa
 
 ### Safe
 
-Support for Linea Sepolia will be added to [safe.linea.build](https://safe.linea.build/welcome) 
-soon.
+Support for Linea Sepolia at [safe.linea.build](https://safe.linea.build/welcome) will be 
+available from early April.
 
 ### Libraries
 

--- a/docs/build-on-linea/goerli-to-sepolia.mdx
+++ b/docs/build-on-linea/goerli-to-sepolia.mdx
@@ -12,7 +12,7 @@ We expect to fully deprecate Linea Goerli by the end of May 2024.
 
 If you run a Linea Goerli testnet node, we recommend you transition to running a Linea Sepolia node as soon as possible.
 
-You will need to spin up a new node. The method is the same as before, and as detailed in our [guide](/build-on-linea/run-a-node). However, you must use new genesis files specific to Linea Sepolia:
+You will need to spin up a new node. The method is the same as before, and as detailed in our [guide](./run-a-node). However, you must use new genesis files specific to Linea Sepolia:
 
 - [Linea Sepolia Geth genesis file](pathname:///files/sepolia/genesis-sepolia-geth.json)
 - [Linea Sepolia Besu genesis file](pathname:///files/sepolia/genesis-sepolia-besu.json)
@@ -34,7 +34,7 @@ For your dapp to remain functional, you must:
 
 ## Linea Sepolia network details
 
-You can find a more thorough overview of key Linea Sepolia details on our [network info page](/use-mainnet/info-contracts). 
+You can find a more thorough overview of key Linea Sepolia details on our [network info page](../use-mainnet/info-contracts). 
 
 Here are the key details:
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -858,6 +858,7 @@ webp
 webpackbar
 wolcott
 WORKDIR
+Worx
 writeups
 wsapi
 xclip


### PR DESCRIPTION
Transitioning to Sepolia impacts a range of tooling, integrations, libraries, etc. This PR expands the page to call out whether a handful of key dependencies are complete (where "complete" == can be used with Sepolia).  