### PR TITLE
Amend contract addresses in Alpha v3 release notes

### DIFF
--- a/docs/build-on-linea/linea-version/index.mdx
+++ b/docs/build-on-linea/linea-version/index.mdx
@@ -30,12 +30,12 @@ can be significantly cheaper in L1 ETH costs depending on market demand.
 L1 and L2 smart contracts have been updated and deployed for Alpha v3. The contract addresses are:
 
 - New verifier contract
-  - Linea Sepolia: [0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79](https://sepolia.lineascan.build/address/0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79)
-  - Linea Mainnet: TBC
-- New L1 message service
-  - Linea Sepolia: [0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5](https://sepolia.lineascan.build/address/0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5)
-  - Linea Mainnet: TBC
-- New L2 rollup contract
+  - Sepolia (L1): [0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79](https://sepolia.etherscan.io/address/0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79)
+  - Ethereum Mainnet: TBC
+- New L1 message service contract
+  - Sepolia (L1): [0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5](https://sepolia.etherscan.io/address/0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5)
+  - Ethereum Mainnet: TBC
+- New L2 message service contract
   - Linea Sepolia: [0x971e727e956690b9957be6d51Ec16E73AcAC83A7](https://sepolia.lineascan.build/address/0x971e727e956690b9957be6d51Ec16E73AcAC83A7)
   - Linea Mainnet: TBC
 


### PR DESCRIPTION
Contracts were incorrectly labelled and linked to the wrong block explorer. The PR fixes this.