### PR TITLE
Update canonical token bridge page

### DIFF
--- a/docs/architecture/bridges/canonical-token-bridge.mdx
+++ b/docs/architecture/bridges/canonical-token-bridge.mdx
@@ -19,7 +19,7 @@ import TabItem from "@theme/TabItem";
 </div>
 
 The canonical token bridge is the pair of “lock & mint” contracts that allow bridging of any 
-ERC-20 token. The bridge relies on the [message service](/docs/architecture/canonical-msg-service/message-service.mdx)
+ERC-20 token. The bridge relies on the [message service](../canonical-msg-service/message-service)
 for cross-chain interactions.
 
 The Linea team operates a UI for this bridge, available at [https://bridge.linea.build/](https://bridge.linea.build/).
@@ -130,7 +130,7 @@ for more information.
 
 1. Triggering the delivery
 
-- See the [message service workflow](/docs/architecture/canonical-msg-service/message-service.mdx#workflow).
+- See the [message service workflow](../canonical-msg-service/message-service.mdx#workflow).
 
 ## Interface TokenBridge.sol
 

--- a/docs/architecture/bridges/canonical-token-bridge.mdx
+++ b/docs/architecture/bridges/canonical-token-bridge.mdx
@@ -1,5 +1,5 @@
 ---
-title: Canonical Token Bridge
+title: Canonical token bridge
 sidebar_position: 1
 image: /img/socialCards/canonical-token-bridge.jpg
 ---
@@ -9,26 +9,38 @@ import TokenBridge from "!!raw-loader!/files/testnet/ITokenBridge.sol";
 import TokenBridgeL1 from "!!raw-loader!/files/testnet/canonical-token-bridge/TokenBridgeL1.abi";
 import TokenBridgeL2 from "!!raw-loader!/files/testnet/canonical-token-bridge/TokenBridgeL2.abi";
 import LineaBridgeGraphic from "/img/article_images/Architecture_of_Linea/Bridges/Canonical_token_bridge/Linea_canonical_token_bridge.svg";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
-# Canonical Token Bridge
+# Canonical token bridge
 
 <div className="img-large">
   <LineaBridgeGraphic />
 </div>
 
-The Canonical Token Bridge is the pair of “lock & mint” contracts that allow bridging of any ERC-20 token. The Bridge relies on the [Message Service](/docs/architecture/canonical-msg-service/message-service.mdx) for cross-chain interactions.
+The canonical token bridge is the pair of “lock & mint” contracts that allow bridging of any 
+ERC-20 token. The bridge relies on the [message service](/docs/architecture/canonical-msg-service/message-service.mdx)
+for cross-chain interactions.
 
 The Linea team operates a UI for this bridge, available at [https://bridge.linea.build/](https://bridge.linea.build/).
 
-The Canonical Token Bridge is optimized for technical partners who are deploying on Linea. We recommend that everyday users of Linea seeking to bridge their personal tokens between networks leverage one of the many bridges deployed to the network.
+The canonical token bridge is optimized for technical partners who are deploying on Linea. 
+We recommend that everyday users of Linea seeking to bridge their personal tokens between 
+networks leverage one of the many bridges deployed to the network.
 
-Linea seeks to foster a permissionless, resilient, decentralized environment--not to have our bridge be a centralized arbiter and point of failure.
+Linea seeks to foster a permissionless, resilient, decentralized environment — not to have our 
+bridge be a centralized arbiter and point of failure.
 
-To find out which bridges are currently operating on Linea, [jump here](https://linea.build/apps), to the Ecosystem Portal on [linea.build](https://linea.build), and click on the "Bridge" button to show all that are available.
+To find out which bridges are currently operating on Linea, head to the [ecosystem portal](https://linea.build/apps) 
+and click on the **Bridge** button to show all that are available.
 
 ## Contracts
 
-- **L1 (Goerli)**
+<Tabs>
+
+<TabItem value="Mainnet" label="Mainnet">
+
+- **Ethereum Mainnet**
 
   <details>
     <summary>TokenBridge.abi</summary>
@@ -36,10 +48,9 @@ To find out which bridges are currently operating on Linea, [jump here](https://
   </details>
 
   - Contracts:
-    - [Transparent Proxy](https://goerli.etherscan.io/address/0x5506A3805fB8A58Fa58248CC52d2b06D92cA94e6)
-    - [Implementation](https://goerli.etherscan.io/address/0x292a9478a52f0b8b12429c58f79367448abe0214#code)
+    - [Canonical token bridge](https://etherscan.io/address/0x051F1D88f0aF5763fB888eC4378b4D8B29ea3319)
 
-- **L2 (Linea)**
+- **Linea Mainnet**
 
   <details>
     <summary>TokenBridge.abi</summary>
@@ -47,8 +58,62 @@ To find out which bridges are currently operating on Linea, [jump here](https://
   </details>
 
   - Contracts:
-    - [Transparent Proxy](https://goerli.lineascan.build/address/0x3ccd0F623B7a25Eab5dFc6a3fD723dCE5520489B)
-    - [Implementation](https://goerli.lineascan.build/address/0x283938e7ae5bf4e9d6a393cdea77c3c369b072e2#code)
+    - [Canonical token bridge](https://lineascan.build/address/0x353012dc4a9a6cf55c941badc267f82004a8ceb9)
+
+</TabItem>
+<TabItem value="Linea Goerli" label="Linea Goerli">
+:::warning
+
+Linea Goerli is being deprecated, and we recommend you use Linea Sepolia instead. See [here](/build-on-linea/goerli-to-sepolia)
+for more information.
+
+:::
+
+- **Ethereum Goerli**
+
+  <details>
+    <summary>TokenBridge.abi</summary>
+    <CodeBlock language="json">{TokenBridgeL1}</CodeBlock>
+  </details>
+
+  - Contracts:
+    - [Canonical token bridge](https://goerli.etherscan.io/address/0x5506A3805fB8A58Fa58248CC52d2b06D92cA94e6)
+
+- **Linea Goerli**
+
+  <details>
+    <summary>TokenBridge.abi</summary>
+    <CodeBlock language="json">{TokenBridgeL2}</CodeBlock>
+  </details>
+
+  - Contracts:
+    - [Canonical token bridge](https://goerli.lineascan.build/address/0x3ccd0F623B7a25Eab5dFc6a3fD723dCE5520489B)
+
+</TabItem>
+<TabItem value="Linea Sepolia" label="Linea Sepolia">
+
+- **Ethereum Sepolia**
+
+  <details>
+    <summary>TokenBridge.abi</summary>
+    <CodeBlock language="json">{TokenBridgeL1}</CodeBlock>
+  </details>
+
+  - Contracts:
+    - [Canonical token bridge](https://sepolia.etherscan.io/address/0x5A0a48389BB0f12E5e017116c1105da97E129142)
+
+- **Linea Sepolia**
+
+  <details>
+    <summary>TokenBridge.abi</summary>
+    <CodeBlock language="json">{TokenBridgeL2}</CodeBlock>
+  </details>
+
+  - Contracts:
+    - [Canonical token bridge](https://sepolia.lineascan.build/address/0x93DcAdf238932e6e6a85852caC89cBd71798F463)
+
+</TabItem>
+</Tabs>
 
 ## How to use
 
@@ -57,7 +122,7 @@ To find out which bridges are currently operating on Linea, [jump here](https://
 1. Triggering the transfer
 
 - **Without Permit**
-  - User should first allow the bridge to transfer tokens on his behalf
+  - User should first allow the bridge to transfer tokens on their behalf
   - This is done by calling `allowance()` on the TokenBridge.
   - Then, the user should call the `bridgeToken()` method.
 - **With Permit**
@@ -65,7 +130,7 @@ To find out which bridges are currently operating on Linea, [jump here](https://
 
 1. Triggering the delivery
 
-- See [Message Service step](/docs/architecture/canonical-msg-service/message-service.mdx#workflow)
+- See the [message service workflow](/docs/architecture/canonical-msg-service/message-service.mdx#workflow).
 
 ## Interface TokenBridge.sol
 

--- a/docs/architecture/bridges/canonical-token-bridge.mdx
+++ b/docs/architecture/bridges/canonical-token-bridge.mdx
@@ -36,7 +36,7 @@ and click on the **Bridge** button to show all that are available.
 
 ## Contracts
 
-<Tabs>
+<Tabs className="my-tabs">
 
 <TabItem value="Mainnet" label="Mainnet">
 


### PR DESCRIPTION
This PR updates the canonical token bridge reference page:
- Adds mainnet contracts
- Adds Sepolia contracts
- Removes `Implementation` contracts