### PR TITLE
Add mainnet contracts to Alpha v3 release notes

### DIFF
--- a/docs/build-on-linea/linea-version/index.mdx
+++ b/docs/build-on-linea/linea-version/index.mdx
@@ -31,13 +31,13 @@ L1 and L2 smart contracts have been updated and deployed for Alpha v3. The contr
 
 - New verifier contract
   - Sepolia (L1): [0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79](https://sepolia.etherscan.io/address/0x5ca5dBf7Cb8F3f3c92E04B16FF5fCA1cdf147f79)
-  - Ethereum Mainnet: TBC
+  - Ethereum Mainnet: [0x8AB455030E1Ea718e445f423Bb8D993dcAd24Cc4](https://etherscan.io/address/0x8AB455030E1Ea718e445f423Bb8D993dcAd24Cc4)
 - New L1 message service contract
   - Sepolia (L1): [0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5](https://sepolia.etherscan.io/address/0xB218f8A4Bc926cF1cA7b3423c154a0D627Bdb7E5)
-  - Ethereum Mainnet: TBC
+  - Ethereum Mainnet: [0xd19d4B5d358258f05D7B411E21A1460D11B0876F](https://etherscan.io/address/0xd19d4B5d358258f05D7B411E21A1460D11B0876F)
 - New L2 message service contract
   - Linea Sepolia: [0x971e727e956690b9957be6d51Ec16E73AcAC83A7](https://sepolia.lineascan.build/address/0x971e727e956690b9957be6d51Ec16E73AcAC83A7)
-  - Linea Mainnet: TBC
+  - Linea Mainnet: [0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec](https://lineascan.build/address/0x508ca82df566dcd1b0de8296e70a96332cd644ec)
 
 Smart contract updates will be executed by the Linea Security Council using the Safe multi-sig 
 procedure. 
@@ -48,9 +48,8 @@ Additionally, all contracts have been audited by OpenZeppelin. You can find the 
 
 - Block time reduced to 3 seconds. This change increases the throughput of the network to avoid
 any potential L2 execution bottlenecks from increased Linea activity.
-- Gas fee reductions. After EIP-4844 is implemented on March 26, we will gather data for 24 hours
-to develop a fuller understanding of the implications for gas fees. Reduced gas fees will then be 
-available to users on March 27. 
+- Gas fee reductions. After EIP-4844 was implemented on March 26, we monitored data for 24 hours
+before reducing gas fees for all users on March 27. 
 
 ### Breaking changes
 


### PR DESCRIPTION
Mainnet contracts have now been deployed, so this PR adds them to the release notes. 