### PR TITLE
Fix Sepolia chain ID in node running instructions

### DIFF
--- a/docs/build-on-linea/run-a-node/use-binary.mdx
+++ b/docs/build-on-linea/run-a-node/use-binary.mdx
@@ -220,7 +220,7 @@ Start the node using the following command:
     ```bash
     geth \
     --datadir $HOME/geth-sepolia-data \
-    --networkid 59140 \
+    --networkid 59141 \
     --rpc.allow-unprotected-txs \
     --txpool.accountqueue 50000 \
     --txpool.globalqueue 50000 \


### PR DESCRIPTION
Chain ID in Geth step 5 was incorrect; fixed to 59141. 