### PR TITLE
Update Lineascan API URL.

### DIFF
--- a/docs/use-mainnet/info-contracts.mdx
+++ b/docs/use-mainnet/info-contracts.mdx
@@ -262,7 +262,7 @@ So, as users take actions on the network, there are changes to those accounts an
 
 | Explorer name | URL | API URL |
 | --- | --- | --- |
-| Lineascan | https://sepolia.lineascan.build | https://api-testnet.lineascan.build/api |
+| Lineascan | https://sepolia.lineascan.build | https://api-sepolia.lineascan.build/api |
 | Blockscout | https://explorer.sepolia.linea.build/ | https://explorer.sepolia.linea.build/api |
 
   </TabItem>

--- a/docs/use-mainnet/info-contracts.mdx
+++ b/docs/use-mainnet/info-contracts.mdx
@@ -251,10 +251,10 @@ So, as users take actions on the network, there are changes to those accounts an
 
 | Explorer name | URL | API URL |
 | --- | --- | --- |
-| Lineascan | https://lineascan.build | https://api.lineascan.build/api |
-| L2Scan | https://linea.l2scan.co | https://linea.l2scan.co/api/contract |
-| Blockscout | https://explorer.linea.build | https://explorer.linea.build/api |
-| OKLink | https://www.oklink.com/linea | https://www.oklink.com/docs/en/#welcome-to-oklink-api |
+| Lineascan | https://lineascan.build | `https://api.lineascan.build/api` |
+| L2Scan | https://linea.l2scan.co | `https://linea.l2scan.co/api/contract` |
+| Blockscout | https://explorer.linea.build | `https://explorer.linea.build/api` |
+| OKLink | https://www.oklink.com/linea | `https://www.oklink.com/docs/en/#welcome-to-oklink-api` |
 
 
   </TabItem>
@@ -262,15 +262,15 @@ So, as users take actions on the network, there are changes to those accounts an
 
 | Explorer name | URL | API URL |
 | --- | --- | --- |
-| Lineascan | https://sepolia.lineascan.build | https://api-sepolia.lineascan.build/api |
-| Blockscout | https://explorer.sepolia.linea.build/ | https://explorer.sepolia.linea.build/api |
+| Lineascan | https://sepolia.lineascan.build | `https://api-sepolia.lineascan.build/api` |
+| Blockscout | https://explorer.sepolia.linea.build/ | `https://explorer.sepolia.linea.build/api` |
 
   </TabItem>
   <TabItem value="Linea Goerli" label="Linea Goerli" default>
 
 | Explorer name | URL | API URL |
 | --- | --- | --- |
-| Lineascan | https://goerli.lineascan.build | https://api-testnet.lineascan.build/api |
+| Lineascan | https://goerli.lineascan.build | `https://api-testnet.lineascan.build/api` |
 
   </TabItem>
 </Tabs>

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -8,6 +8,10 @@
       },
       {
         "pattern": "https://support.metamask.io/"
+      },
+      {
+        "pattern": "https://infura.io/faucet/linea"
       }
     ]
   }
+  


### PR DESCRIPTION
Update Lineascan API URL.

I updated the links for the APIs to formatted code, because it appears they can potentially cause the CI to fail because it might expect parameters to be passed as well. 